### PR TITLE
extract main API from Assert

### DIFF
--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -1,4 +1,216 @@
 require "much-stub/version"
 
 module MuchStub
+
+  def self.stubs
+    @stubs ||= {}
+  end
+
+  def self.stub(obj, meth, &block)
+    (self.stubs[MuchStub::Stub.key(obj, meth)] ||= begin
+      MuchStub::Stub.new(obj, meth, caller_locations)
+    end).tap{ |s| s.do = block }
+  end
+
+  def self.unstub(obj, meth)
+    (self.stubs.delete(MuchStub::Stub.key(obj, meth)) || MuchStub::NullStub.new).teardown
+  end
+
+  def self.unstub!
+    self.stubs.keys.each{ |key| self.stubs.delete(key).teardown }
+  end
+
+  def self.stub_send(obj, meth, *args, &block)
+    orig_caller = caller_locations
+    stub = self.stubs.fetch(MuchStub::Stub.key(obj, meth)) do
+      raise NotStubbedError, "`#{meth}` not stubbed.", orig_caller.map(&:to_s)
+    end
+    stub.call_method(args, &block)
+  end
+
+  class Stub
+
+    def self.key(object, method_name)
+      "--#{object.object_id}--#{method_name}--"
+    end
+
+    attr_reader :method_name, :name, :ivar_name, :do
+
+    def initialize(object, method_name, orig_caller = nil, &block)
+      orig_caller ||= caller_locations
+      @metaclass   = class << object; self; end
+      @method_name = method_name.to_s
+      @name        = "__muchstub_stub__#{object.object_id}_#{@method_name}"
+      @ivar_name   = "@__muchstub_stub_#{object.object_id}_" \
+                     "#{@method_name.to_sym.object_id}"
+
+      setup(object, orig_caller)
+
+      @do     = block
+      @lookup = {}
+    end
+
+    def do=(block)
+      @do = block || @do
+    end
+
+    def call_method(args, &block)
+      @method.call(*args, &block)
+    end
+
+    def call(args, orig_caller = nil, &block)
+      orig_caller ||= caller_locations
+      unless arity_matches?(args)
+        msg = "arity mismatch on `#{@method_name}`: " \
+              "expected #{number_of_args(@method.arity)}, " \
+              "called with #{args.size}"
+        raise StubArityError, msg, orig_caller.map(&:to_s)
+      end
+      lookup(args, orig_caller).call(*args, &block)
+    rescue NotStubbedError => exception
+      @lookup.rehash
+      lookup(args, orig_caller).call(*args, &block)
+    end
+
+    def with(*args, &block)
+      orig_caller = caller_locations
+      unless arity_matches?(args)
+        msg = "arity mismatch on `#{@method_name}`: " \
+              "expected #{number_of_args(@method.arity)}, " \
+              "stubbed with #{args.size}"
+        raise StubArityError, msg, orig_caller.map(&:to_s)
+      end
+      @lookup[args] = block
+    end
+
+    def teardown
+      @metaclass.send(:undef_method, @method_name)
+      MuchStub.send(:remove_instance_variable, @ivar_name)
+      @metaclass.send(:alias_method, @method_name, @name)
+      @metaclass.send(:undef_method, @name)
+    end
+
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)}" \
+      " @method_name=#{@method_name.inspect}" \
+      ">"
+    end
+
+    private
+
+    def setup(object, orig_caller)
+      unless object.respond_to?(@method_name)
+        msg = "#{object.inspect} does not respond to `#{@method_name}`"
+        raise StubError, msg, orig_caller.map(&:to_s)
+      end
+      is_constant          = object.kind_of?(Module)
+      local_object_methods = object.methods(false).map(&:to_s)
+      all_object_methods   = object.methods.map(&:to_s)
+      if (is_constant && !local_object_methods.include?(@method_name)) ||
+         (!is_constant && !all_object_methods.include?(@method_name))
+        params_list = ParameterList.new(object, @method_name)
+        @metaclass.class_eval <<-method
+          def #{@method_name}(#{params_list}); super; end
+        method
+      end
+
+      if !local_object_methods.include?(@name) # already stubbed
+        @metaclass.send(:alias_method, @name, @method_name)
+      end
+      @method = object.method(@name)
+
+      MuchStub.instance_variable_set(@ivar_name, self)
+      @metaclass.class_eval <<-stub_method
+        def #{@method_name}(*args, &block)
+          MuchStub.instance_variable_get("#{@ivar_name}").call(args, caller_locations, &block)
+        end
+      stub_method
+    end
+
+    def lookup(args, orig_caller)
+      @lookup.fetch(args) do
+        self.do || begin
+          msg = "#{inspect_call(args)} not stubbed."
+          inspect_lookup_stubs.tap do |stubs|
+            msg += "\nStubs:\n#{stubs}" if !stubs.empty?
+          end
+          raise NotStubbedError, msg, orig_caller.map(&:to_s)
+        end
+      end
+    end
+
+    def arity_matches?(args)
+      return true if @method.arity == args.size # mandatory args
+      return true if @method.arity < 0 && args.size >= (@method.arity+1).abs # variable args
+      return false
+    end
+
+    def inspect_lookup_stubs
+      @lookup.keys.map{ |args| "    - #{inspect_call(args)}" }.join("\n")
+    end
+
+    def inspect_call(args)
+      "`#{@method_name}(#{args.map(&:inspect).join(',')})`"
+    end
+
+    def number_of_args(arity)
+      if arity < 0
+        "at least #{(arity + 1).abs}"
+      else
+        arity
+      end
+    end
+
+  end
+
+  StubError       = Class.new(ArgumentError)
+  NotStubbedError = Class.new(StubError)
+  StubArityError  = Class.new(StubError)
+
+  NullStub = Class.new do
+    def teardown; end # no-op
+  end
+
+  module ParameterList
+
+    LETTERS = ('a'..'z').to_a.freeze
+
+    def self.new(object, method_name)
+      arity = get_arity(object, method_name)
+      params = build_params_from_arity(arity)
+      params << '*args' if arity < 0
+      params << '&block'
+      params.join(', ')
+    end
+
+    private
+
+    def self.get_arity(object, method_name)
+      object.method(method_name).arity
+    rescue NameError
+      -1
+    end
+
+    def self.build_params_from_arity(arity)
+      number = arity < 0 ? (arity + 1).abs : arity
+      (0..(number - 1)).map{ |param_index| get_param_name(param_index) }
+    end
+
+    def self.get_param_name(param_index)
+      param_index += LETTERS.size # avoid getting 0 for the number of letters
+      number_of_letters, letter_index = param_index.divmod(LETTERS.size)
+      LETTERS[letter_index] * number_of_letters
+    end
+
+  end
+
+end
+
+# Kernel#caller_locations polyfill for pre ruby 2.0.0
+if RUBY_VERSION =~ /\A1\..+/ && !Kernel.respond_to?(:caller_locations)
+  module Kernel
+    def caller_locations(start = 1, length = nil)
+      length ? caller[start, length] : caller[start..-1]
+    end
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,3 +17,9 @@ if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
     alias_method :sample, :choice
   end
 end
+
+# unstub all test stubs automatically for Assert test suite
+require 'assert'
+class Assert::Context
+  teardown{ MuchStub.unstub! }
+end

--- a/test/system/much-stub_tests.rb
+++ b/test/system/much-stub_tests.rb
@@ -1,0 +1,754 @@
+require 'assert'
+require 'much-stub'
+
+module MuchStub
+
+  class SystemTests < Assert::Context
+    desc "MuchStub"
+
+  end
+
+  class InstanceTests < SystemTests
+    desc "for instance methods"
+    setup do
+      @instance = TestClass.new
+      MuchStub.stub(@instance, :noargs){ 'default' }
+      MuchStub.stub(@instance, :noargs).with{ 'none' }
+
+      MuchStub.stub(@instance, :withargs){ 'default' }
+      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@instance, :anyargs){ 'default' }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@instance, :minargs){ 'default' }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@instance, :withblock){ 'default' }
+    end
+    subject{ @instance }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_raises{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
+
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
+
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
+
+      assert_raises{ subject.withblock(1) }
+    end
+
+  end
+
+  class ClassTests < SystemTests
+    desc "for singleton methods on a class"
+    setup do
+      @class = TestClass
+      MuchStub.stub(@class, :noargs){ 'default' }
+      MuchStub.stub(@class, :noargs).with{ 'none' }
+
+      MuchStub.stub(@class, :withargs){ 'default' }
+      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@class, :anyargs){ 'default' }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@class, :minargs){ 'default' }
+      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@class, :withblock){ 'default' }
+    end
+    subject{ @class }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_raises{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
+
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
+
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
+
+      assert_raises{ subject.withblock(1) }
+    end
+
+  end
+
+  class ModuleTests < SystemTests
+    desc "for singleton methods on a module"
+    setup do
+      @module = TestModule
+      MuchStub.stub(@module, :noargs){ 'default' }
+      MuchStub.stub(@module, :noargs).with{ 'none' }
+
+      MuchStub.stub(@module, :withargs){ 'default' }
+      MuchStub.stub(@module, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@module, :anyargs){ 'default' }
+      MuchStub.stub(@module, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@module, :minargs){ 'default' }
+      MuchStub.stub(@module, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@module, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@module, :withblock){ 'default' }
+    end
+    subject{ @module }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_raises{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
+
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
+
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
+
+      assert_raises{ subject.withblock(1) }
+    end
+
+  end
+
+  class ExtendedTests < SystemTests
+    desc "for extended methods"
+    setup do
+      @class = Class.new{ extend TestMixin }
+      MuchStub.stub(@class, :noargs){ 'default' }
+      MuchStub.stub(@class, :noargs).with{ 'none' }
+
+      MuchStub.stub(@class, :withargs){ 'default' }
+      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@class, :anyargs){ 'default' }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@class, :minargs){ 'default' }
+      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@class, :withblock){ 'default' }
+    end
+    subject{ @class }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_raises{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
+
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
+
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
+
+      assert_raises{ subject.withblock(1) }
+    end
+
+  end
+
+  class IncludedTests < SystemTests
+    desc "for an included method"
+    setup do
+      @class = Class.new{ include TestMixin }
+      @instance = @class.new
+      MuchStub.stub(@instance, :noargs){ 'default' }
+      MuchStub.stub(@instance, :noargs).with{ 'none' }
+
+      MuchStub.stub(@instance, :withargs){ 'default' }
+      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@instance, :anyargs){ 'default' }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@instance, :minargs){ 'default' }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@instance, :withblock){ 'default' }
+    end
+    subject{ @instance }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_raises{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
+
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
+
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
+
+      assert_raises{ subject.withblock(1) }
+    end
+
+  end
+
+  class InheritedClassTests < SystemTests
+    desc "for an inherited class method"
+    setup do
+      @class = Class.new(TestClass)
+      MuchStub.stub(@class, :noargs){ 'default' }
+      MuchStub.stub(@class, :noargs).with{ 'none' }
+
+      MuchStub.stub(@class, :withargs){ 'default' }
+      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@class, :anyargs){ 'default' }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@class, :minargs){ 'default' }
+      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@class, :withblock){ 'default' }
+    end
+    subject{ @class }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_raises{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
+
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
+
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
+
+      assert_raises{ subject.withblock(1) }
+    end
+
+  end
+
+  class InheritedInstanceTests < SystemTests
+    desc "for an inherited instance method"
+    setup do
+      @class = Class.new(TestClass)
+      @instance = @class.new
+      MuchStub.stub(@instance, :noargs){ 'default' }
+      MuchStub.stub(@instance, :noargs).with{ 'none' }
+
+      MuchStub.stub(@instance, :withargs){ 'default' }
+      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@instance, :anyargs){ 'default' }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@instance, :minargs){ 'default' }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@instance, :withblock){ 'default' }
+    end
+    subject{ @instance }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "not allow stubbing methods with invalid arity" do
+      assert_raises{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_raises{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_raises{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_raises{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "not allow calling methods with invalid arity" do
+      assert_raises{ subject.noargs(1) }
+
+      assert_raises{ subject.withargs }
+      assert_raises{ subject.withargs(1, 2) }
+
+      assert_raises{ subject.minargs }
+      assert_raises{ subject.minargs(1) }
+
+      assert_raises{ subject.withblock(1) }
+    end
+
+  end
+
+  class DelegateClassTests < SystemTests
+    desc "a class that delegates another object"
+    setup do
+      @class = DelegateClass
+      MuchStub.stub(@class, :noargs){ 'default' }
+      MuchStub.stub(@class, :noargs).with{ 'none' }
+
+      MuchStub.stub(@class, :withargs){ 'default' }
+      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@class, :anyargs){ 'default' }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@class, :minargs){ 'default' }
+      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@class, :withblock){ 'default' }
+    end
+    subject{ @class }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "allow stubbing methods with invalid arity" do
+      assert_nothing_raised{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_nothing_raised{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_nothing_raised{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_nothing_raised{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_nothing_raised{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_nothing_raised{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "allow calling methods with invalid arity" do
+      assert_nothing_raised{ subject.noargs(1) }
+
+      assert_nothing_raised{ subject.withargs }
+      assert_nothing_raised{ subject.withargs(1, 2) }
+
+      assert_nothing_raised{ subject.minargs }
+      assert_nothing_raised{ subject.minargs(1) }
+
+      assert_nothing_raised{ subject.withblock(1) }
+    end
+
+  end
+
+  class DelegateInstanceTests < SystemTests
+    desc "an instance that delegates another object"
+    setup do
+      @instance = DelegateClass.new
+      MuchStub.stub(@instance, :noargs){ 'default' }
+      MuchStub.stub(@instance, :noargs).with{ 'none' }
+
+      MuchStub.stub(@instance, :withargs){ 'default' }
+      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+
+      MuchStub.stub(@instance, :anyargs){ 'default' }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+
+      MuchStub.stub(@instance, :minargs){ 'default' }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+
+      MuchStub.stub(@instance, :withblock){ 'default' }
+    end
+    subject{ @instance }
+
+    should "allow stubbing a method that doesn't take args" do
+      assert_equal 'none', subject.noargs
+    end
+
+    should "allow stubbing a method that takes args" do
+      assert_equal 'one',     subject.withargs(1)
+      assert_equal 'default', subject.withargs(2)
+    end
+
+    should "allow stubbing a method that takes any args" do
+      assert_equal 'default', subject.anyargs
+      assert_equal 'default', subject.anyargs(1)
+      assert_equal 'one-two', subject.anyargs(1, 2)
+    end
+
+    should "allow stubbing a method that takes a minimum number of args" do
+      assert_equal 'one-two',       subject.minargs(1, 2)
+      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
+      assert_equal 'default',       subject.minargs(1, 2, 4)
+      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+    end
+
+    should "allow stubbing a method that takes a block" do
+      assert_equal 'default', subject.withblock
+      assert_equal 'default', subject.withblock{ 'my-block' }
+    end
+
+    should "allow stubbing methods with invalid arity" do
+      assert_nothing_raised{ MuchStub.stub(subject, :noargs).with(1){ } }
+
+      assert_nothing_raised{ MuchStub.stub(subject, :withargs).with{ } }
+      assert_nothing_raised{ MuchStub.stub(subject, :withargs).with(1, 2){ } }
+
+      assert_nothing_raised{ MuchStub.stub(subject, :minargs).with{ } }
+      assert_nothing_raised{ MuchStub.stub(subject, :minargs).with(1){ } }
+
+      assert_nothing_raised{ MuchStub.stub(subject, :withblock).with(1){ } }
+    end
+
+    should "allow calling methods with invalid arity" do
+      assert_nothing_raised{ subject.noargs(1) }
+
+      assert_nothing_raised{ subject.withargs }
+      assert_nothing_raised{ subject.withargs(1, 2) }
+
+      assert_nothing_raised{ subject.minargs }
+      assert_nothing_raised{ subject.minargs(1) }
+
+      assert_nothing_raised{ subject.withblock(1) }
+    end
+
+  end
+
+  class ParentAndChildClassTests < SystemTests
+    desc "for a parent method stubbed on both the parent and child"
+    setup do
+      @parent_class = Class.new
+      @child_class = Class.new(@parent_class)
+
+      MuchStub.stub(@parent_class, :new){ 'parent' }
+      MuchStub.stub(@child_class, :new){ 'child' }
+    end
+
+    should "allow stubbing the methods individually" do
+      assert_equal 'parent', @parent_class.new
+      assert_equal 'child', @child_class.new
+    end
+
+  end
+
+  class TestClass
+
+    def self.noargs; end
+    def self.withargs(a); end
+    def self.anyargs(*args); end
+    def self.minargs(a, b, *args); end
+    def self.withblock(&block); end
+
+    def noargs; end
+    def withargs(a); end
+    def anyargs(*args); end
+    def minargs(a, b, *args); end
+    def withblock(&block); end
+
+  end
+
+  module TestModule
+
+    def self.noargs; end
+    def self.withargs(a); end
+    def self.anyargs(*args); end
+    def self.minargs(a, b, *args); end
+    def self.withblock(&block); end
+
+  end
+
+  module TestMixin
+
+    def noargs; end
+    def withargs(a); end
+    def anyargs(*args); end
+    def minargs(a, b, *args); end
+    def withblock(&block); end
+
+  end
+
+  class DelegateClass
+    def self.respond_to?(*args)
+      TestClass.respond_to?(*args) || super
+    end
+
+    def self.method_missing(name, *args, &block)
+      TestClass.respond_to?(name) ? TestClass.send(name, *args, &block) : super
+    end
+
+    def initialize
+      @delegate = TestClass.new
+    end
+
+    def respond_to?(*args)
+      @delegate.respond_to?(*args) || super
+    end
+
+    def method_missing(name, *args, &block)
+      @delegate.respond_to?(name) ? @delegate.send(name, *args, &block) : super
+    end
+  end
+
+end

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -1,0 +1,447 @@
+require 'assert'
+require 'much-stub'
+
+require 'test/support/factory'
+
+module MuchStub
+
+  class UnitTests < Assert::Context
+    desc "MuchStub"
+  end
+
+  class ApiTests < UnitTests
+    desc "api"
+    setup do
+      @orig_value = Factory.string
+      @stub_value = Factory.string
+
+      @myclass = Class.new do
+        def initialize(value); @value = value; end
+        def mymeth; @value; end
+      end
+      @myobj = @myclass.new(@orig_value)
+    end
+
+    should "build a stub" do
+      stub1 = MuchStub.stub(@myobj, :mymeth)
+      assert_kind_of MuchStub::Stub, stub1
+    end
+
+    should "lookup stubs that have been called before" do
+      stub1 = MuchStub.stub(@myobj, :mymeth)
+      stub2 = MuchStub.stub(@myobj, :mymeth)
+      assert_same stub1, stub2
+    end
+
+    should "set the stub's do block if given a block" do
+      MuchStub.stub(@myobj, :mymeth)
+      assert_raises(MuchStub::NotStubbedError){ @myobj.mymeth }
+      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+      assert_equal @stub_value, @myobj.mymeth
+    end
+
+    should "teardown stubs" do
+      assert_equal @orig_value, @myobj.mymeth
+      MuchStub.unstub(@myobj, :mymeth)
+      assert_equal @orig_value, @myobj.mymeth
+
+      assert_equal @orig_value, @myobj.mymeth
+      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+      assert_equal @stub_value, @myobj.mymeth
+      MuchStub.unstub(@myobj, :mymeth)
+      assert_equal @orig_value, @myobj.mymeth
+    end
+
+    should "know and teardown all stubs" do
+      assert_equal @orig_value, @myobj.mymeth
+
+      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+      assert_equal @stub_value, @myobj.mymeth
+      assert_equal 1, MuchStub.stubs.size
+
+      MuchStub.unstub!
+      assert_equal @orig_value, @myobj.mymeth
+      assert_empty MuchStub.stubs
+    end
+
+    should "be able to call a stub's original method" do
+      err = assert_raises(NotStubbedError){ MuchStub.stub_send(@myobj, :mymeth) }
+      assert_includes 'not stubbed.',                 err.message
+      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+
+      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+
+      assert_equal @stub_value, @myobj.mymeth
+      assert_equal @orig_value, MuchStub.stub_send(@myobj, :mymeth)
+    end
+
+  end
+
+  class StubTests < UnitTests
+    desc "Stub"
+    setup do
+      @myclass = Class.new do
+        def mymeth; 'meth'; end
+        def myval(val); val; end
+        def myargs(*args); args; end
+        def myvalargs(val1, val2, *args); [val1, val2, args]; end
+        def myblk(&block); block.call; end
+      end
+      @myobj = @myclass.new
+
+      @stub = MuchStub::Stub.new(@myobj, :mymeth)
+    end
+    subject{ @stub }
+
+    should have_readers :method_name, :name, :ivar_name, :do
+    should have_writers :do
+    should have_cmeths :key
+    should have_imeths :call_method, :call, :with, :teardown
+
+    should "generate a key given an object and method name" do
+      obj = @myobj
+      meth = :mymeth
+      assert_equal "--#{obj.object_id}--#{meth}--", MuchStub::Stub.key(obj, meth)
+    end
+
+    should "know its names" do
+      assert_equal 'mymeth', subject.method_name
+      expected = "__muchstub_stub__#{@myobj.object_id}_#{subject.method_name}"
+      assert_equal expected, subject.name
+      expected = "@__muchstub_stub_#{@myobj.object_id}_" \
+                 "#{subject.method_name.to_sym.object_id}"
+      assert_equal expected, subject.ivar_name
+    end
+
+    should "complain when called if no do block was given" do
+      err = assert_raises(MuchStub::NotStubbedError){ @myobj.mymeth }
+      assert_includes 'not stubbed.',                 err.message
+      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+
+      subject.do = proc{ 'mymeth' }
+      assert_nothing_raised do
+        @myobj.mymeth
+      end
+
+      assert_nothing_raised do
+        MuchStub::Stub.new(@myobj, :mymeth){ 'mymeth' }
+      end
+    end
+
+    should "complain if stubbing a method that the object doesn't respond to" do
+      err = assert_raises(MuchStub::StubError){ MuchStub::Stub.new(@myobj, :some_other_meth) }
+      assert_includes 'does not respond to',     err.message
+      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+    end
+
+    should "complain if stubbed and called with no `do` proc given" do
+      assert_raises(MuchStub::NotStubbedError){ @myobj.mymeth }
+    end
+
+    should "complain if stubbed and called with mismatched arity" do
+      MuchStub::Stub.new(@myobj, :myval){ 'myval' }
+      err = assert_raises(MuchStub::StubArityError){ @myobj.myval }
+      assert_includes 'arity mismatch on',       err.message
+      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+
+      assert_nothing_raised { @myobj.myval(1) }
+      assert_raises(MuchStub::StubArityError){ @myobj.myval(1,2) }
+
+      MuchStub::Stub.new(@myobj, :myargs){ 'myargs' }
+      assert_nothing_raised { @myobj.myargs }
+      assert_nothing_raised { @myobj.myargs(1) }
+      assert_nothing_raised { @myobj.myargs(1,2) }
+
+      MuchStub::Stub.new(@myobj, :myvalargs){ 'myvalargs' }
+      assert_raises(MuchStub::StubArityError){ @myobj.myvalargs }
+      assert_raises(MuchStub::StubArityError){ @myobj.myvalargs(1) }
+      assert_nothing_raised { @myobj.myvalargs(1,2) }
+      assert_nothing_raised { @myobj.myvalargs(1,2,3) }
+    end
+
+    should "complain if stubbed with mismatched arity" do
+      err = assert_raises(MuchStub::StubArityError) do
+        MuchStub::Stub.new(@myobj, :myval).with(){ 'myval' }
+      end
+      assert_includes 'arity mismatch on',       err.message
+      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+
+      assert_raises(MuchStub::StubArityError) do
+        MuchStub::Stub.new(@myobj, :myval).with(1,2){ 'myval' }
+      end
+      assert_nothing_raised do
+        MuchStub::Stub.new(@myobj, :myval).with(1){ 'myval' }
+      end
+
+      assert_nothing_raised do
+        MuchStub::Stub.new(@myobj, :myargs).with(){ 'myargs' }
+      end
+      assert_nothing_raised do
+        MuchStub::Stub.new(@myobj, :myargs).with(1,2){ 'myargs' }
+      end
+      assert_nothing_raised do
+        MuchStub::Stub.new(@myobj, :myargs).with(1){ 'myargs' }
+      end
+
+      assert_raises(MuchStub::StubArityError) do
+        MuchStub::Stub.new(@myobj, :myvalargs).with(){ 'myvalargs' }
+      end
+      assert_raises(MuchStub::StubArityError) do
+        MuchStub::Stub.new(@myobj, :myvalargs).with(1){ 'myvalargs' }
+      end
+      assert_nothing_raised do
+        MuchStub::Stub.new(@myobj, :myvalargs).with(1,2){ 'myvalargs' }
+      end
+      assert_nothing_raised do
+        MuchStub::Stub.new(@myobj, :myvalargs).with(1,2,3){ 'myvalargs' }
+      end
+    end
+
+    should "stub methods with no args" do
+      subject.teardown
+
+      assert_equal 'meth', @myobj.mymeth
+      MuchStub::Stub.new(@myobj, :mymeth){ 'mymeth' }
+      assert_equal 'mymeth', @myobj.mymeth
+    end
+
+    should "stub methods with required arg" do
+      assert_equal 1, @myobj.myval(1)
+      stub = MuchStub::Stub.new(@myobj, :myval){ |val| val.to_s }
+      assert_equal '1', @myobj.myval(1)
+      assert_equal '2', @myobj.myval(2)
+      stub.with(2){ 'two' }
+      assert_equal 'two', @myobj.myval(2)
+    end
+
+    should "stub methods with variable args" do
+      assert_equal [1,2], @myobj.myargs(1,2)
+      stub = MuchStub::Stub.new(@myobj, :myargs){ |*args| args.join(',') }
+      assert_equal '1,2', @myobj.myargs(1,2)
+      assert_equal '3,4,5', @myobj.myargs(3,4,5)
+      stub.with(3,4,5){ 'three-four-five' }
+      assert_equal 'three-four-five', @myobj.myargs(3,4,5)
+    end
+
+    should "stub methods with required args and variable args" do
+      assert_equal [1,2, [3]], @myobj.myvalargs(1,2,3)
+      stub = MuchStub::Stub.new(@myobj, :myvalargs){ |*args| args.join(',') }
+      assert_equal '1,2,3', @myobj.myvalargs(1,2,3)
+      assert_equal '3,4,5', @myobj.myvalargs(3,4,5)
+      stub.with(3,4,5){ 'three-four-five' }
+      assert_equal 'three-four-five', @myobj.myvalargs(3,4,5)
+    end
+
+    should "stub methods that yield blocks" do
+      blkcalled = false
+      blk = proc{ blkcalled = true }
+      @myobj.myblk(&blk)
+      assert_equal true, blkcalled
+
+      blkcalled = false
+      MuchStub::Stub.new(@myobj, :myblk){ blkcalled = 'true' }
+      @myobj.myblk(&blk)
+      assert_equal 'true', blkcalled
+    end
+
+    should "stub methods even if they are not local to the object" do
+      mydelegatorclass = Class.new do
+        def initialize(delegateclass)
+          @delegate = delegateclass.new
+        end
+        def respond_to?(meth)
+          @delegate.respond_to?(meth) || super
+        end
+        def method_missing(meth, *args, &block)
+          respond_to?(meth) ? @delegate.send(meth, *args, &block) : super
+        end
+      end
+      mydelegator = mydelegatorclass.new(@myclass)
+
+      assert_equal [1,2,[3]], mydelegator.myvalargs(1,2,3)
+      stub = MuchStub::Stub.new(mydelegator, :myvalargs){ |*args| args.inspect }
+      assert_equal '[1, 2, 3]', mydelegator.myvalargs(1,2,3)
+      assert_equal '[4, 5, 6]', mydelegator.myvalargs(4,5,6)
+      stub.with(4,5,6){ 'four-five-six' }
+      assert_equal 'four-five-six', mydelegator.myvalargs(4,5,6)
+    end
+
+    should "call to the original method" do
+      subject.teardown
+
+      # no args
+      stub = MuchStub::Stub.new(@myobj, :mymeth){ 'mymeth' }
+      assert_equal 'mymeth', stub.call([])
+      assert_equal 'meth',   stub.call_method([])
+
+      # static args
+      stub = MuchStub::Stub.new(@myobj, :myval){ |val| val.to_s }
+      assert_equal '1', stub.call([1])
+      assert_equal 1,   stub.call_method([1])
+      assert_equal '2', stub.call([2])
+      assert_equal 2,   stub.call_method([2])
+      stub.with(2){ 'two' }
+      assert_equal 'two', stub.call([2])
+      assert_equal 2,     stub.call_method([2])
+
+      # dynamic args
+      stub = MuchStub::Stub.new(@myobj, :myargs){ |*args| args.join(',') }
+      assert_equal '1,2',   stub.call([1,2])
+      assert_equal [1,2],   stub.call_method([1,2])
+      assert_equal '3,4,5', stub.call([3,4,5])
+      assert_equal [3,4,5], stub.call_method([3,4,5])
+      stub.with(3,4,5){ 'three-four-five' }
+      assert_equal 'three-four-five', stub.call([3,4,5])
+      assert_equal [3,4,5],           stub.call_method([3,4,5])
+
+      # mixed static/dynamic args
+      stub = MuchStub::Stub.new(@myobj, :myvalargs){ |*args| args.join(',') }
+      assert_equal '1,2,3',    stub.call([1,2,3])
+      assert_equal [1,2, [3]], stub.call_method([1,2,3])
+      assert_equal '3,4,5',    stub.call([3,4,5])
+      assert_equal [3,4,[5]],  stub.call_method([3,4,5])
+      stub.with(3,4,5){ 'three-four-five' }
+      assert_equal 'three-four-five', stub.call([3,4,5])
+      assert_equal [3,4,[5]],         stub.call_method([3,4,5])
+
+      # blocks
+      blkcalled = false
+      blk = proc{ blkcalled = true }
+      stub = MuchStub::Stub.new(@myobj, :myblk){ blkcalled = 'true' }
+      stub.call([], &blk)
+      assert_equal 'true', blkcalled
+      stub.call_method([], &blk)
+      assert_equal true, blkcalled
+    end
+
+    should "store and remove itself on asserts main module" do
+      assert_equal subject, MuchStub.instance_variable_get(subject.ivar_name)
+      subject.teardown
+      assert_nil MuchStub.instance_variable_get(subject.ivar_name)
+    end
+
+    should "be removable" do
+      assert_equal 1, @myobj.myval(1)
+      stub = MuchStub::Stub.new(@myobj, :myval){ |val| val.to_s }
+      assert_equal '1', @myobj.myval(1)
+      stub.teardown
+      assert_equal 1, @myobj.myval(1)
+    end
+
+    should "have a readable inspect" do
+      expected = "#<#{subject.class}:#{'0x0%x' % (subject.object_id << 1)}" \
+                 " @method_name=#{subject.method_name.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
+  end
+
+  class MutatingArgsStubTests < StubTests
+    desc "with args that are mutated after they've been used to stub"
+    setup do
+      @arg = ChangeHashObject.new
+
+      @stub = MuchStub::Stub.new(@myobj, :myval)
+      @stub.with(@arg){ true }
+
+      @arg.change!
+    end
+    subject{ @stub }
+
+    should "not raise a stub error when called" do
+      assert_nothing_raised{ @stub.call([@arg]) }
+    end
+
+  end
+
+  class StubInheritedMethodAfterStubbedOnParentTests < StubTests
+    desc "stubbing an inherited method after its stubbed on the parent class"
+    setup do
+      @parent_class = Class.new
+      @child_class = Class.new(@parent_class)
+
+      @parent_stub = MuchStub::Stub.new(@parent_class, :new)
+      @child_stub = MuchStub::Stub.new(@child_class, :new)
+    end
+
+    should "allow stubbing them independently of each other" do
+      assert_nothing_raised do
+        @parent_stub.with(1, 2){ 'parent' }
+        @child_stub.with(1, 2){ 'child' }
+      end
+      assert_equal 'parent', @parent_class.new(1, 2)
+      assert_equal 'child', @child_class.new(1, 2)
+    end
+
+    should "not raise any errors when tearing down the parent before the child" do
+      assert_nothing_raised do
+        @parent_stub.teardown
+        @child_stub.teardown
+      end
+    end
+
+  end
+
+  class NullStubTests < UnitTests
+    desc "NullStub"
+    setup do
+      @ns = NullStub.new
+    end
+    subject{ @ns }
+
+    should have_imeths :teardown
+
+  end
+
+  class ParameterListTests < UnitTests
+    desc "ParameterList"
+    setup do
+      many_args = (0..ParameterList::LETTERS.size).map do
+        Assert::Factory.string
+      end.join(', ')
+      @object = Class.new
+      # use `class_eval` with string to easily define methods with many params
+      @object.class_eval <<-methods
+        def self.noargs; end
+        def self.anyargs(*args); end
+        def self.manyargs(#{many_args}); end
+        def self.minargs(#{many_args}, *args); end
+      methods
+    end
+    subject{ ParameterList }
+
+    should "build a parameter list for a method that takes no args" do
+      assert_equal '&block', subject.new(@object, 'noargs')
+    end
+
+    should "build a parameter list for a method that takes any args" do
+      assert_equal '*args, &block', subject.new(@object, 'anyargs')
+    end
+
+    should "build a parameter list for a method that takes many args" do
+      expected = "#{ParameterList::LETTERS.join(', ')}, aa, &block"
+      assert_equal expected, subject.new(@object, 'manyargs')
+    end
+
+    should "build a parameter list for a method that takes a minimum number of args" do
+      expected = "#{ParameterList::LETTERS.join(', ')}, aa, *args, &block"
+      assert_equal expected, subject.new(@object, 'minargs')
+    end
+
+  end
+
+  class ChangeHashObject
+    def initialize
+      @value = nil
+    end
+
+    def hash
+      @value.hash
+    end
+
+    def change!
+      @value = 1
+    end
+  end
+
+end


### PR DESCRIPTION
This extracts the stubbing API from Assert and reworks it as
MuchStub.  All of the API is remaining the same, but instead of
calling `Assert.{stub|unstub|stub_send|etc}` you now call
`MuchStub.{stub|unstub|stub_send|etc}`.  The usage doesn't change.

Note: I chose to move the custom errors classes and the `NullStub`
and `ParameterList` under the main `MuchStub` namespace.  Assert
had them under the `Assert::Stub` namespace, but I'm not sure why.
It makes more sense to have them just below the main `MuchStub`
namespace.

Note: the only other difference is that Assert auto-unstubs on
test context teardowns.  It isn't appropriate and is not the
intent of MuchStub to auto do this (b/c it would differ based on
which testing framework you used).  Therefore, the MuchStub test
helpers manually add a teardown to unstub their Assert test
contexts.

Note: this also pulls over the `caller_locations` Ruby 1.8.7 
polyfill from Assert.  This is needed for 1.8.7 compatibility.
We prefer `caller_locations` as it is more performant than
`caller`.

@jcredding ready for review.  Nothing API-wise is changing here, just moving from Assert to MuchStub.  I've tested this in Assert's test suite.  I will test a few of our apps with this next to make sure nothing is broken.