### PR TITLE
add `MuchStub.call` for creating stubs; allows `MuchStub.()` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Note: this was originally implemented in and extracted from [Assert](https://git
 ## Usage
 
 ```ruby
+# Given this object/API
+
 myclass = Class.new do
   def mymeth; 'meth'; end
   def myval(val); val; end
@@ -26,6 +28,8 @@ myobj.myval(123)
   # => 123
 myobj.myval(456)
   # => 456
+
+# Create a new stub for the :mymeth method
 
 MuchStub.(myobj, :mymeth)
 myobj.mymeth
@@ -40,6 +44,8 @@ MuchStub.(myobj, :mymeth).with(123){ 'stub-meth' }
 MuchStub.stub_send(myobj, :mymeth) # call to the original method post-stub
   # => 'meth'
 
+# Create a new stub for the :myval method
+
 MuchStub.(myobj, :myval){ 'stub-meth' }
   # => StubError: arity mismatch
 MuchStub.(myobj, :myval).with(123){ |val| val.to_s }
@@ -49,13 +55,24 @@ myobj.myval(123)
   # => '123'
 myobj.myval(456)
   # => StubError: `myval(456)` not stubbed.
-MuchStub.stub_send(myobj, :myval, 123) # call to the original method post-stub
+
+# Call to the original method post-stub
+
+MuchStub.stub_send(myobj, :myval, 123)
   # => 123
 MuchStub.stub_send(myobj, :myval, 456)
   # => 456
 
+# Unstub individual stubs
+
 MuchStub.unstub(myobj, :mymeth)
 MuchStub.unstub(myobj, :myval)
+
+# OR blanket unstub all stubs
+
+MuchStub.unstub!
+
+# Original API is preserved after unstubbing
 
 myobj.mymeth
   # => 'meth'

--- a/README.md
+++ b/README.md
@@ -27,22 +27,22 @@ myobj.myval(123)
 myobj.myval(456)
   # => 456
 
-MuchStub.stub(myobj, :mymeth)
+MuchStub.(myobj, :mymeth)
 myobj.mymeth
   # => StubError: `mymeth` not stubbed.
-MuchStub.stub(myobj, :mymeth){ 'stub-meth' }
+MuchStub.(myobj, :mymeth){ 'stub-meth' }
 myobj.mymeth
   # => 'stub-meth'
 myobj.mymeth(123)
   # => StubError: arity mismatch
-MuchStub.stub(myobj, :mymeth).with(123){ 'stub-meth' }
+MuchStub.(myobj, :mymeth).with(123){ 'stub-meth' }
   # => StubError: arity mismatch
 MuchStub.stub_send(myobj, :mymeth) # call to the original method post-stub
   # => 'meth'
 
-MuchStub.stub(myobj, :myval){ 'stub-meth' }
+MuchStub.(myobj, :myval){ 'stub-meth' }
   # => StubError: arity mismatch
-MuchStub.stub(myobj, :myval).with(123){ |val| val.to_s }
+MuchStub.(myobj, :myval).with(123){ |val| val.to_s }
 myobj.myval
   # => StubError: arity mismatch
 myobj.myval(123)

--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -6,6 +6,10 @@ module MuchStub
     @stubs ||= {}
   end
 
+  def self.call(*args, &block)
+    self.stub(*args, &block)
+  end
+
   def self.stub(obj, meth, &block)
     (self.stubs[MuchStub::Stub.key(obj, meth)] ||= begin
       MuchStub::Stub.new(obj, meth, caller_locations)

--- a/much-stub.gemspec
+++ b/much-stub.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.3"])
+  gem.add_development_dependency("assert", ["~> 2.17.0"])
 
 end

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -23,20 +23,23 @@ module MuchStub
     end
 
     should "build a stub" do
-      stub1 = MuchStub.stub(@myobj, :mymeth)
+      stub1 = MuchStub.(@myobj, :mymeth)
       assert_kind_of MuchStub::Stub, stub1
+
+      stub2 = MuchStub.call(@myobj, :mymeth)
+      assert_kind_of MuchStub::Stub, stub2
     end
 
     should "lookup stubs that have been called before" do
-      stub1 = MuchStub.stub(@myobj, :mymeth)
-      stub2 = MuchStub.stub(@myobj, :mymeth)
+      stub1 = MuchStub.(@myobj, :mymeth)
+      stub2 = MuchStub.(@myobj, :mymeth)
       assert_same stub1, stub2
     end
 
     should "set the stub's do block if given a block" do
-      MuchStub.stub(@myobj, :mymeth)
+      MuchStub.(@myobj, :mymeth)
       assert_raises(MuchStub::NotStubbedError){ @myobj.mymeth }
-      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+      MuchStub.(@myobj, :mymeth){ @stub_value }
       assert_equal @stub_value, @myobj.mymeth
     end
 
@@ -46,7 +49,7 @@ module MuchStub
       assert_equal @orig_value, @myobj.mymeth
 
       assert_equal @orig_value, @myobj.mymeth
-      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+      MuchStub.(@myobj, :mymeth){ @stub_value }
       assert_equal @stub_value, @myobj.mymeth
       MuchStub.unstub(@myobj, :mymeth)
       assert_equal @orig_value, @myobj.mymeth
@@ -55,7 +58,7 @@ module MuchStub
     should "know and teardown all stubs" do
       assert_equal @orig_value, @myobj.mymeth
 
-      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+      MuchStub.(@myobj, :mymeth){ @stub_value }
       assert_equal @stub_value, @myobj.mymeth
       assert_equal 1, MuchStub.stubs.size
 
@@ -69,7 +72,7 @@ module MuchStub
       assert_includes 'not stubbed.',                 err.message
       assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
 
-      MuchStub.stub(@myobj, :mymeth){ @stub_value }
+      MuchStub.(@myobj, :mymeth){ @stub_value }
 
       assert_equal @stub_value, @myobj.mymeth
       assert_equal @orig_value, MuchStub.stub_send(@myobj, :mymeth)


### PR DESCRIPTION
This is a more terse and UX-friendly way to build a stub and
emphasizes how creating stubs is the main point of MuchStub.
Plus, the `MuchStub.stub` API is kinda redundant.

I chose to keep the `MuchStub.stub` API for backwards compatibility
reasons and b/c it doesn't hurt anything if users prefer using it.

## Other Changes

#### add extra "section comments" to the README usage docs

The goal here is to try and guide the reader with context more in
the usage docs.

#### update to the latest Assert

Just keeping up with the latest stuff.

@jcredding ready for review.