### PR TITLE
add `MuchStub.tap`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'pry', "~> 0.9.0"
+gem "pry", "~> 0.12.2"

--- a/README.md
+++ b/README.md
@@ -187,6 +187,85 @@ thing.built_with
   # => [123]
 ```
 
+### `MuchStub.tap`
+
+Use the `.tap` method to spy on method calls while preserving the original method return value and behavior.
+
+```ruby
+# Given this object/API
+
+my_class = Class.new do
+  def basic_method(value)
+    value.to_s
+  end
+end
+my_object = my_class.new
+
+# Normal stubs override the original behavior and return value...
+basic_method_called_with = nil
+MuchStub.(my_object, :basic_method) { |*args|
+  basic_method_called_with = args
+}
+
+# ... in this case not converting the value to a String and returning it and
+# instead returning the arguments passed to the method.
+my_object.basic_method(123)
+  # => [123]
+basic_method_called_with
+  # => [123]
+
+# Use `MuchStub.tap` to preserve the methods behavior and also spy.
+
+basic_method_called_with = nil
+MuchStub.tap(my_object, :basic_method) { |value, *args|
+  basic_method_called_with = args
+}
+
+my_object.basic_method(123)
+  # => "123"
+basic_method_called_with
+  # => [123]
+```
+
+#### Late-bound stubs using `MuchStub.tap`
+
+Use the `.tap` method to stub any return values of method calls.
+
+```ruby
+# Given:
+
+class Thing
+  attr_reader :value
+
+  def initialize(value)
+    @value = value
+  end
+end
+
+my_class = Class.new do
+  def thing(value)
+    Thing.new(value)
+  end
+end
+my_object = my_class.new
+
+# Use `MuchStub.tap` to stub any thing instances created by `my_object.thing`
+# (and also spy on the call arguments)
+
+thing_built_with = nil
+MuchStub.tap(my_object, :thing) { |thing, *args|
+  thing_built_with = args
+  MuchStub.(thing, :value) { 456 }
+}
+
+thing = my_object.thing(123)
+  # => #<Thing:0x00007fd5ca9df510 @value=123>
+thing_built_with
+  # => [123]
+thing.value
+  # => 456
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Note: this was originally implemented in and extracted from [Assert](https://git
 # Given this object/API
 
 myclass = Class.new do
-  def mymeth; 'meth'; end
+  def mymeth; "meth"; end
   def myval(val); val; end
 end
 myobj = myclass.new
 
 myobj.mymeth
-  # => 'meth'
+  # => "meth"
 myobj.myval(123)
   # => 123
 myobj.myval(456)
@@ -34,25 +34,25 @@ myobj.myval(456)
 MuchStub.(myobj, :mymeth)
 myobj.mymeth
   # => StubError: `mymeth` not stubbed.
-MuchStub.(myobj, :mymeth){ 'stub-meth' }
+MuchStub.(myobj, :mymeth){ "stub-meth" }
 myobj.mymeth
-  # => 'stub-meth'
+  # => "stub-meth"
 myobj.mymeth(123)
   # => StubError: arity mismatch
-MuchStub.(myobj, :mymeth).with(123){ 'stub-meth' }
+MuchStub.(myobj, :mymeth).with(123){ "stub-meth" }
   # => StubError: arity mismatch
 MuchStub.stub_send(myobj, :mymeth) # call to the original method post-stub
-  # => 'meth'
+  # => "meth"
 
 # Create a new stub for the :myval method
 
-MuchStub.(myobj, :myval){ 'stub-meth' }
+MuchStub.(myobj, :myval){ "stub-meth" }
   # => StubError: arity mismatch
 MuchStub.(myobj, :myval).with(123){ |val| val.to_s }
 myobj.myval
   # => StubError: arity mismatch
 myobj.myval(123)
-  # => '123'
+  # => "123"
 myobj.myval(456)
   # => StubError: `myval(456)` not stubbed.
 
@@ -75,7 +75,7 @@ MuchStub.unstub!
 # Original API is preserved after unstubbing
 
 myobj.mymeth
-  # => 'meth'
+  # => "meth"
 myobj.myval(123)
   # => 123
 myobj.myval(456)
@@ -86,7 +86,7 @@ myobj.myval(456)
 
 Add this line to your application's Gemfile:
 
-    gem 'much-stub'
+    gem "much-stub"
 
 And then execute:
 
@@ -100,6 +100,6 @@ Or install it yourself as:
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Added some feature'`)
+3. Commit your changes (`git commit -am "Added some feature"`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request

--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -1,7 +1,6 @@
 require "much-stub/version"
 
 module MuchStub
-
   def self.stubs
     @stubs ||= {}
   end
@@ -38,7 +37,6 @@ module MuchStub
   end
 
   class Stub
-
     def self.key(object, method_name)
       "--#{object.object_id}--#{method_name}--"
     end
@@ -100,7 +98,7 @@ module MuchStub
     end
 
     def inspect
-      "#<#{self.class}:#{'0x0%x' % (object_id << 1)}" \
+      "#<#{self.class}:#{"0x0%x" % (object_id << 1)}" \
       " @method_name=#{@method_name.inspect}" \
       ">"
     end
@@ -159,7 +157,7 @@ module MuchStub
     end
 
     def inspect_call(args)
-      "`#{@method_name}(#{args.map(&:inspect).join(',')})`"
+      "`#{@method_name}(#{args.map(&:inspect).join(",")})`"
     end
 
     def number_of_args(arity)
@@ -169,7 +167,6 @@ module MuchStub
         arity
       end
     end
-
   end
 
   StubError       = Class.new(ArgumentError)
@@ -181,15 +178,14 @@ module MuchStub
   end
 
   module ParameterList
-
-    LETTERS = ('a'..'z').to_a.freeze
+    LETTERS = ("a".."z").to_a.freeze
 
     def self.new(object, method_name)
       arity = get_arity(object, method_name)
       params = build_params_from_arity(arity)
-      params << '*args' if arity < 0
-      params << '&block'
-      params.join(', ')
+      params << "*args" if arity < 0
+      params << "&block"
+      params.join(", ")
     end
 
     private
@@ -210,9 +206,7 @@ module MuchStub
       number_of_letters, letter_index = param_index.divmod(LETTERS.size)
       LETTERS[letter_index] * number_of_letters
     end
-
   end
-
 end
 
 # Kernel#caller_locations polyfill for pre ruby 2.0.0

--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -36,6 +36,14 @@ module MuchStub
     stub.call_method(args, &block)
   end
 
+  def self.tap(obj, meth, &tap_block)
+    self.stub(obj, meth) { |*args, &block|
+      self.stub_send(obj, meth, *args, &block).tap { |value|
+        tap_block.call(value, *args, &block) if tap_block
+      }
+    }
+  end
+
   class Stub
     def self.key(object, method_name)
       "--#{object.object_id}--#{method_name}--"

--- a/much-stub.gemspec
+++ b/much-stub.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "much-stub/version"
 
@@ -11,13 +11,13 @@ Gem::Specification.new do |gem|
   gem.summary     = "Stubbing API for replacing method calls on objects in test runs."
   gem.description = "Stubbing API for replacing method calls on objects in test runs."
   gem.homepage    = "https://github.com/redding/much-stub"
-  gem.license     = 'MIT'
+  gem.license     = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.17.0"])
+  gem.add_development_dependency("assert", ["~> 2.18.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,9 +5,9 @@
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
-require 'pry'
+require "pry"
 
-require 'test/support/factory'
+require "test/support/factory"
 
 # 1.8.7 backfills
 
@@ -19,7 +19,7 @@ if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
 end
 
 # unstub all test stubs automatically for Assert test suite
-require 'assert'
+require "assert"
 class Assert::Context
   teardown{ MuchStub.unstub! }
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,6 +1,5 @@
-require 'assert/factory'
+require "assert/factory"
 
 module Factory
   extend Assert::Factory
-
 end

--- a/test/system/much-stub_tests.rb
+++ b/test/system/much-stub_tests.rb
@@ -1,59 +1,57 @@
-require 'assert'
-require 'much-stub'
+require "assert"
+require "much-stub"
 
 module MuchStub
-
   class SystemTests < Assert::Context
     desc "MuchStub"
-
   end
 
   class InstanceTests < SystemTests
     desc "for instance methods"
     setup do
       @instance = TestClass.new
-      MuchStub.stub(@instance, :noargs){ 'default' }
-      MuchStub.stub(@instance, :noargs).with{ 'none' }
+      MuchStub.stub(@instance, :noargs){ "default" }
+      MuchStub.stub(@instance, :noargs).with{ "none" }
 
-      MuchStub.stub(@instance, :withargs){ 'default' }
-      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+      MuchStub.stub(@instance, :withargs){ "default" }
+      MuchStub.stub(@instance, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@instance, :anyargs){ 'default' }
-      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :anyargs){ "default" }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@instance, :minargs){ 'default' }
-      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@instance, :minargs){ "default" }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@instance, :withblock){ 'default' }
+      MuchStub.stub(@instance, :withblock){ "default" }
     end
     subject{ @instance }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "not allow stubbing methods with invalid arity" do
@@ -79,55 +77,54 @@ module MuchStub
 
       assert_raises{ subject.withblock(1) }
     end
-
   end
 
   class ClassTests < SystemTests
     desc "for singleton methods on a class"
     setup do
       @class = TestClass
-      MuchStub.stub(@class, :noargs){ 'default' }
-      MuchStub.stub(@class, :noargs).with{ 'none' }
+      MuchStub.stub(@class, :noargs){ "default" }
+      MuchStub.stub(@class, :noargs).with{ "none" }
 
-      MuchStub.stub(@class, :withargs){ 'default' }
-      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+      MuchStub.stub(@class, :withargs){ "default" }
+      MuchStub.stub(@class, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@class, :anyargs){ 'default' }
-      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :anyargs){ "default" }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@class, :minargs){ 'default' }
-      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@class, :minargs){ "default" }
+      MuchStub.stub(@class, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@class, :withblock){ 'default' }
+      MuchStub.stub(@class, :withblock){ "default" }
     end
     subject{ @class }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "not allow stubbing methods with invalid arity" do
@@ -153,55 +150,54 @@ module MuchStub
 
       assert_raises{ subject.withblock(1) }
     end
-
   end
 
   class ModuleTests < SystemTests
     desc "for singleton methods on a module"
     setup do
       @module = TestModule
-      MuchStub.stub(@module, :noargs){ 'default' }
-      MuchStub.stub(@module, :noargs).with{ 'none' }
+      MuchStub.stub(@module, :noargs){ "default" }
+      MuchStub.stub(@module, :noargs).with{ "none" }
 
-      MuchStub.stub(@module, :withargs){ 'default' }
-      MuchStub.stub(@module, :withargs).with(1){ 'one' }
+      MuchStub.stub(@module, :withargs){ "default" }
+      MuchStub.stub(@module, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@module, :anyargs){ 'default' }
-      MuchStub.stub(@module, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@module, :anyargs){ "default" }
+      MuchStub.stub(@module, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@module, :minargs){ 'default' }
-      MuchStub.stub(@module, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@module, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@module, :minargs){ "default" }
+      MuchStub.stub(@module, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@module, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@module, :withblock){ 'default' }
+      MuchStub.stub(@module, :withblock){ "default" }
     end
     subject{ @module }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "not allow stubbing methods with invalid arity" do
@@ -227,55 +223,54 @@ module MuchStub
 
       assert_raises{ subject.withblock(1) }
     end
-
   end
 
   class ExtendedTests < SystemTests
     desc "for extended methods"
     setup do
       @class = Class.new{ extend TestMixin }
-      MuchStub.stub(@class, :noargs){ 'default' }
-      MuchStub.stub(@class, :noargs).with{ 'none' }
+      MuchStub.stub(@class, :noargs){ "default" }
+      MuchStub.stub(@class, :noargs).with{ "none" }
 
-      MuchStub.stub(@class, :withargs){ 'default' }
-      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+      MuchStub.stub(@class, :withargs){ "default" }
+      MuchStub.stub(@class, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@class, :anyargs){ 'default' }
-      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :anyargs){ "default" }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@class, :minargs){ 'default' }
-      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@class, :minargs){ "default" }
+      MuchStub.stub(@class, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@class, :withblock){ 'default' }
+      MuchStub.stub(@class, :withblock){ "default" }
     end
     subject{ @class }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "not allow stubbing methods with invalid arity" do
@@ -301,7 +296,6 @@ module MuchStub
 
       assert_raises{ subject.withblock(1) }
     end
-
   end
 
   class IncludedTests < SystemTests
@@ -309,48 +303,48 @@ module MuchStub
     setup do
       @class = Class.new{ include TestMixin }
       @instance = @class.new
-      MuchStub.stub(@instance, :noargs){ 'default' }
-      MuchStub.stub(@instance, :noargs).with{ 'none' }
+      MuchStub.stub(@instance, :noargs){ "default" }
+      MuchStub.stub(@instance, :noargs).with{ "none" }
 
-      MuchStub.stub(@instance, :withargs){ 'default' }
-      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+      MuchStub.stub(@instance, :withargs){ "default" }
+      MuchStub.stub(@instance, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@instance, :anyargs){ 'default' }
-      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :anyargs){ "default" }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@instance, :minargs){ 'default' }
-      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@instance, :minargs){ "default" }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@instance, :withblock){ 'default' }
+      MuchStub.stub(@instance, :withblock){ "default" }
     end
     subject{ @instance }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "not allow stubbing methods with invalid arity" do
@@ -376,55 +370,54 @@ module MuchStub
 
       assert_raises{ subject.withblock(1) }
     end
-
   end
 
   class InheritedClassTests < SystemTests
     desc "for an inherited class method"
     setup do
       @class = Class.new(TestClass)
-      MuchStub.stub(@class, :noargs){ 'default' }
-      MuchStub.stub(@class, :noargs).with{ 'none' }
+      MuchStub.stub(@class, :noargs){ "default" }
+      MuchStub.stub(@class, :noargs).with{ "none" }
 
-      MuchStub.stub(@class, :withargs){ 'default' }
-      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+      MuchStub.stub(@class, :withargs){ "default" }
+      MuchStub.stub(@class, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@class, :anyargs){ 'default' }
-      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :anyargs){ "default" }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@class, :minargs){ 'default' }
-      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@class, :minargs){ "default" }
+      MuchStub.stub(@class, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@class, :withblock){ 'default' }
+      MuchStub.stub(@class, :withblock){ "default" }
     end
     subject{ @class }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "not allow stubbing methods with invalid arity" do
@@ -450,7 +443,6 @@ module MuchStub
 
       assert_raises{ subject.withblock(1) }
     end
-
   end
 
   class InheritedInstanceTests < SystemTests
@@ -458,48 +450,48 @@ module MuchStub
     setup do
       @class = Class.new(TestClass)
       @instance = @class.new
-      MuchStub.stub(@instance, :noargs){ 'default' }
-      MuchStub.stub(@instance, :noargs).with{ 'none' }
+      MuchStub.stub(@instance, :noargs){ "default" }
+      MuchStub.stub(@instance, :noargs).with{ "none" }
 
-      MuchStub.stub(@instance, :withargs){ 'default' }
-      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+      MuchStub.stub(@instance, :withargs){ "default" }
+      MuchStub.stub(@instance, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@instance, :anyargs){ 'default' }
-      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :anyargs){ "default" }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@instance, :minargs){ 'default' }
-      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@instance, :minargs){ "default" }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@instance, :withblock){ 'default' }
+      MuchStub.stub(@instance, :withblock){ "default" }
     end
     subject{ @instance }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "not allow stubbing methods with invalid arity" do
@@ -525,55 +517,54 @@ module MuchStub
 
       assert_raises{ subject.withblock(1) }
     end
-
   end
 
   class DelegateClassTests < SystemTests
     desc "a class that delegates another object"
     setup do
       @class = DelegateClass
-      MuchStub.stub(@class, :noargs){ 'default' }
-      MuchStub.stub(@class, :noargs).with{ 'none' }
+      MuchStub.stub(@class, :noargs){ "default" }
+      MuchStub.stub(@class, :noargs).with{ "none" }
 
-      MuchStub.stub(@class, :withargs){ 'default' }
-      MuchStub.stub(@class, :withargs).with(1){ 'one' }
+      MuchStub.stub(@class, :withargs){ "default" }
+      MuchStub.stub(@class, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@class, :anyargs){ 'default' }
-      MuchStub.stub(@class, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@class, :anyargs){ "default" }
+      MuchStub.stub(@class, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@class, :minargs){ 'default' }
-      MuchStub.stub(@class, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@class, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@class, :minargs){ "default" }
+      MuchStub.stub(@class, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@class, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@class, :withblock){ 'default' }
+      MuchStub.stub(@class, :withblock){ "default" }
     end
     subject{ @class }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "allow stubbing methods with invalid arity" do
@@ -599,55 +590,54 @@ module MuchStub
 
       assert_nothing_raised{ subject.withblock(1) }
     end
-
   end
 
   class DelegateInstanceTests < SystemTests
     desc "an instance that delegates another object"
     setup do
       @instance = DelegateClass.new
-      MuchStub.stub(@instance, :noargs){ 'default' }
-      MuchStub.stub(@instance, :noargs).with{ 'none' }
+      MuchStub.stub(@instance, :noargs){ "default" }
+      MuchStub.stub(@instance, :noargs).with{ "none" }
 
-      MuchStub.stub(@instance, :withargs){ 'default' }
-      MuchStub.stub(@instance, :withargs).with(1){ 'one' }
+      MuchStub.stub(@instance, :withargs){ "default" }
+      MuchStub.stub(@instance, :withargs).with(1){ "one" }
 
-      MuchStub.stub(@instance, :anyargs){ 'default' }
-      MuchStub.stub(@instance, :anyargs).with(1, 2){ 'one-two' }
+      MuchStub.stub(@instance, :anyargs){ "default" }
+      MuchStub.stub(@instance, :anyargs).with(1, 2){ "one-two" }
 
-      MuchStub.stub(@instance, :minargs){ 'default' }
-      MuchStub.stub(@instance, :minargs).with(1, 2){ 'one-two' }
-      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ 'one-two-three' }
+      MuchStub.stub(@instance, :minargs){ "default" }
+      MuchStub.stub(@instance, :minargs).with(1, 2){ "one-two" }
+      MuchStub.stub(@instance, :minargs).with(1, 2, 3){ "one-two-three" }
 
-      MuchStub.stub(@instance, :withblock){ 'default' }
+      MuchStub.stub(@instance, :withblock){ "default" }
     end
     subject{ @instance }
 
     should "allow stubbing a method that doesn't take args" do
-      assert_equal 'none', subject.noargs
+      assert_equal "none", subject.noargs
     end
 
     should "allow stubbing a method that takes args" do
-      assert_equal 'one',     subject.withargs(1)
-      assert_equal 'default', subject.withargs(2)
+      assert_equal "one",     subject.withargs(1)
+      assert_equal "default", subject.withargs(2)
     end
 
     should "allow stubbing a method that takes any args" do
-      assert_equal 'default', subject.anyargs
-      assert_equal 'default', subject.anyargs(1)
-      assert_equal 'one-two', subject.anyargs(1, 2)
+      assert_equal "default", subject.anyargs
+      assert_equal "default", subject.anyargs(1)
+      assert_equal "one-two", subject.anyargs(1, 2)
     end
 
     should "allow stubbing a method that takes a minimum number of args" do
-      assert_equal 'one-two',       subject.minargs(1, 2)
-      assert_equal 'one-two-three', subject.minargs(1, 2, 3)
-      assert_equal 'default',       subject.minargs(1, 2, 4)
-      assert_equal 'default',       subject.minargs(1, 2, 3, 4)
+      assert_equal "one-two",       subject.minargs(1, 2)
+      assert_equal "one-two-three", subject.minargs(1, 2, 3)
+      assert_equal "default",       subject.minargs(1, 2, 4)
+      assert_equal "default",       subject.minargs(1, 2, 3, 4)
     end
 
     should "allow stubbing a method that takes a block" do
-      assert_equal 'default', subject.withblock
-      assert_equal 'default', subject.withblock{ 'my-block' }
+      assert_equal "default", subject.withblock
+      assert_equal "default", subject.withblock{ "my-block" }
     end
 
     should "allow stubbing methods with invalid arity" do
@@ -673,7 +663,6 @@ module MuchStub
 
       assert_nothing_raised{ subject.withblock(1) }
     end
-
   end
 
   class ParentAndChildClassTests < SystemTests
@@ -682,19 +671,17 @@ module MuchStub
       @parent_class = Class.new
       @child_class = Class.new(@parent_class)
 
-      MuchStub.stub(@parent_class, :new){ 'parent' }
-      MuchStub.stub(@child_class, :new){ 'child' }
+      MuchStub.stub(@parent_class, :new){ "parent" }
+      MuchStub.stub(@child_class, :new){ "child" }
     end
 
     should "allow stubbing the methods individually" do
-      assert_equal 'parent', @parent_class.new
-      assert_equal 'child', @child_class.new
+      assert_equal "parent", @parent_class.new
+      assert_equal "child", @child_class.new
     end
-
   end
 
   class TestClass
-
     def self.noargs; end
     def self.withargs(a); end
     def self.anyargs(*args); end
@@ -706,27 +693,22 @@ module MuchStub
     def anyargs(*args); end
     def minargs(a, b, *args); end
     def withblock(&block); end
-
   end
 
   module TestModule
-
     def self.noargs; end
     def self.withargs(a); end
     def self.anyargs(*args); end
     def self.minargs(a, b, *args); end
     def self.withblock(&block); end
-
   end
 
   module TestMixin
-
     def noargs; end
     def withargs(a); end
     def anyargs(*args); end
     def minargs(a, b, *args); end
     def withblock(&block); end
-
   end
 
   class DelegateClass
@@ -750,5 +732,4 @@ module MuchStub
       @delegate.respond_to?(name) ? @delegate.send(name, *args, &block) : super
     end
   end
-
 end

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -76,6 +76,16 @@ module MuchStub
       assert_equal @stub_value, @myobj.mymeth
       assert_equal @orig_value, MuchStub.stub_send(@myobj, :mymeth)
     end
+
+    should "be able to add a stub tap" do
+      my_meth_called_with = nil
+      MuchStub.tap(@myobj, :mymeth){ |value, *args, &block|
+        my_meth_called_with = args
+      }
+
+      assert_equal @orig_value, @myobj.mymeth
+      assert_equal [], my_meth_called_with
+    end
   end
 
   class StubTests < UnitTests

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -1,16 +1,15 @@
-require 'assert'
-require 'much-stub'
+require "assert"
+require "much-stub"
 
-require 'test/support/factory'
+require "test/support/factory"
 
 module MuchStub
-
   class UnitTests < Assert::Context
     desc "MuchStub"
   end
 
-  class ApiTests < UnitTests
-    desc "api"
+  class APITests < UnitTests
+    desc "API"
     setup do
       @orig_value = Factory.string
       @stub_value = Factory.string
@@ -69,22 +68,21 @@ module MuchStub
 
     should "be able to call a stub's original method" do
       err = assert_raises(NotStubbedError){ MuchStub.stub_send(@myobj, :mymeth) }
-      assert_includes 'not stubbed.',                 err.message
-      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+      assert_includes "not stubbed.",                 err.message
+      assert_includes "test/unit/much-stub_tests.rb", err.backtrace.first
 
       MuchStub.(@myobj, :mymeth){ @stub_value }
 
       assert_equal @stub_value, @myobj.mymeth
       assert_equal @orig_value, MuchStub.stub_send(@myobj, :mymeth)
     end
-
   end
 
   class StubTests < UnitTests
     desc "Stub"
     setup do
       @myclass = Class.new do
-        def mymeth; 'meth'; end
+        def mymeth; "meth"; end
         def myval(val); val; end
         def myargs(*args); args; end
         def myvalargs(val1, val2, *args); [val1, val2, args]; end
@@ -108,7 +106,7 @@ module MuchStub
     end
 
     should "know its names" do
-      assert_equal 'mymeth', subject.method_name
+      assert_equal "mymeth", subject.method_name
       expected = "__muchstub_stub__#{@myobj.object_id}_#{subject.method_name}"
       assert_equal expected, subject.name
       expected = "@__muchstub_stub_#{@myobj.object_id}_" \
@@ -118,23 +116,23 @@ module MuchStub
 
     should "complain when called if no do block was given" do
       err = assert_raises(MuchStub::NotStubbedError){ @myobj.mymeth }
-      assert_includes 'not stubbed.',                 err.message
-      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+      assert_includes "not stubbed.",                 err.message
+      assert_includes "test/unit/much-stub_tests.rb", err.backtrace.first
 
-      subject.do = proc{ 'mymeth' }
+      subject.do = proc{ "mymeth" }
       assert_nothing_raised do
         @myobj.mymeth
       end
 
       assert_nothing_raised do
-        MuchStub::Stub.new(@myobj, :mymeth){ 'mymeth' }
+        MuchStub::Stub.new(@myobj, :mymeth){ "mymeth" }
       end
     end
 
     should "complain if stubbing a method that the object doesn't respond to" do
       err = assert_raises(MuchStub::StubError){ MuchStub::Stub.new(@myobj, :some_other_meth) }
-      assert_includes 'does not respond to',     err.message
-      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+      assert_includes "does not respond to",     err.message
+      assert_includes "test/unit/much-stub_tests.rb", err.backtrace.first
     end
 
     should "complain if stubbed and called with no `do` proc given" do
@@ -142,20 +140,20 @@ module MuchStub
     end
 
     should "complain if stubbed and called with mismatched arity" do
-      MuchStub::Stub.new(@myobj, :myval){ 'myval' }
+      MuchStub::Stub.new(@myobj, :myval){ "myval" }
       err = assert_raises(MuchStub::StubArityError){ @myobj.myval }
-      assert_includes 'arity mismatch on',       err.message
-      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+      assert_includes "arity mismatch on",       err.message
+      assert_includes "test/unit/much-stub_tests.rb", err.backtrace.first
 
       assert_nothing_raised { @myobj.myval(1) }
       assert_raises(MuchStub::StubArityError){ @myobj.myval(1,2) }
 
-      MuchStub::Stub.new(@myobj, :myargs){ 'myargs' }
+      MuchStub::Stub.new(@myobj, :myargs){ "myargs" }
       assert_nothing_raised { @myobj.myargs }
       assert_nothing_raised { @myobj.myargs(1) }
       assert_nothing_raised { @myobj.myargs(1,2) }
 
-      MuchStub::Stub.new(@myobj, :myvalargs){ 'myvalargs' }
+      MuchStub::Stub.new(@myobj, :myvalargs){ "myvalargs" }
       assert_raises(MuchStub::StubArityError){ @myobj.myvalargs }
       assert_raises(MuchStub::StubArityError){ @myobj.myvalargs(1) }
       assert_nothing_raised { @myobj.myvalargs(1,2) }
@@ -164,75 +162,75 @@ module MuchStub
 
     should "complain if stubbed with mismatched arity" do
       err = assert_raises(MuchStub::StubArityError) do
-        MuchStub::Stub.new(@myobj, :myval).with(){ 'myval' }
+        MuchStub::Stub.new(@myobj, :myval).with(){ "myval" }
       end
-      assert_includes 'arity mismatch on',       err.message
-      assert_includes 'test/unit/much-stub_tests.rb', err.backtrace.first
+      assert_includes "arity mismatch on",       err.message
+      assert_includes "test/unit/much-stub_tests.rb", err.backtrace.first
 
       assert_raises(MuchStub::StubArityError) do
-        MuchStub::Stub.new(@myobj, :myval).with(1,2){ 'myval' }
+        MuchStub::Stub.new(@myobj, :myval).with(1,2){ "myval" }
       end
       assert_nothing_raised do
-        MuchStub::Stub.new(@myobj, :myval).with(1){ 'myval' }
+        MuchStub::Stub.new(@myobj, :myval).with(1){ "myval" }
       end
 
       assert_nothing_raised do
-        MuchStub::Stub.new(@myobj, :myargs).with(){ 'myargs' }
+        MuchStub::Stub.new(@myobj, :myargs).with(){ "myargs" }
       end
       assert_nothing_raised do
-        MuchStub::Stub.new(@myobj, :myargs).with(1,2){ 'myargs' }
+        MuchStub::Stub.new(@myobj, :myargs).with(1,2){ "myargs" }
       end
       assert_nothing_raised do
-        MuchStub::Stub.new(@myobj, :myargs).with(1){ 'myargs' }
+        MuchStub::Stub.new(@myobj, :myargs).with(1){ "myargs" }
       end
 
       assert_raises(MuchStub::StubArityError) do
-        MuchStub::Stub.new(@myobj, :myvalargs).with(){ 'myvalargs' }
+        MuchStub::Stub.new(@myobj, :myvalargs).with(){ "myvalargs" }
       end
       assert_raises(MuchStub::StubArityError) do
-        MuchStub::Stub.new(@myobj, :myvalargs).with(1){ 'myvalargs' }
+        MuchStub::Stub.new(@myobj, :myvalargs).with(1){ "myvalargs" }
       end
       assert_nothing_raised do
-        MuchStub::Stub.new(@myobj, :myvalargs).with(1,2){ 'myvalargs' }
+        MuchStub::Stub.new(@myobj, :myvalargs).with(1,2){ "myvalargs" }
       end
       assert_nothing_raised do
-        MuchStub::Stub.new(@myobj, :myvalargs).with(1,2,3){ 'myvalargs' }
+        MuchStub::Stub.new(@myobj, :myvalargs).with(1,2,3){ "myvalargs" }
       end
     end
 
     should "stub methods with no args" do
       subject.teardown
 
-      assert_equal 'meth', @myobj.mymeth
-      MuchStub::Stub.new(@myobj, :mymeth){ 'mymeth' }
-      assert_equal 'mymeth', @myobj.mymeth
+      assert_equal "meth", @myobj.mymeth
+      MuchStub::Stub.new(@myobj, :mymeth){ "mymeth" }
+      assert_equal "mymeth", @myobj.mymeth
     end
 
     should "stub methods with required arg" do
       assert_equal 1, @myobj.myval(1)
       stub = MuchStub::Stub.new(@myobj, :myval){ |val| val.to_s }
-      assert_equal '1', @myobj.myval(1)
-      assert_equal '2', @myobj.myval(2)
-      stub.with(2){ 'two' }
-      assert_equal 'two', @myobj.myval(2)
+      assert_equal "1", @myobj.myval(1)
+      assert_equal "2", @myobj.myval(2)
+      stub.with(2){ "two" }
+      assert_equal "two", @myobj.myval(2)
     end
 
     should "stub methods with variable args" do
       assert_equal [1,2], @myobj.myargs(1,2)
-      stub = MuchStub::Stub.new(@myobj, :myargs){ |*args| args.join(',') }
-      assert_equal '1,2', @myobj.myargs(1,2)
-      assert_equal '3,4,5', @myobj.myargs(3,4,5)
-      stub.with(3,4,5){ 'three-four-five' }
-      assert_equal 'three-four-five', @myobj.myargs(3,4,5)
+      stub = MuchStub::Stub.new(@myobj, :myargs){ |*args| args.join(",") }
+      assert_equal "1,2", @myobj.myargs(1,2)
+      assert_equal "3,4,5", @myobj.myargs(3,4,5)
+      stub.with(3,4,5){ "three-four-five" }
+      assert_equal "three-four-five", @myobj.myargs(3,4,5)
     end
 
     should "stub methods with required args and variable args" do
       assert_equal [1,2, [3]], @myobj.myvalargs(1,2,3)
-      stub = MuchStub::Stub.new(@myobj, :myvalargs){ |*args| args.join(',') }
-      assert_equal '1,2,3', @myobj.myvalargs(1,2,3)
-      assert_equal '3,4,5', @myobj.myvalargs(3,4,5)
-      stub.with(3,4,5){ 'three-four-five' }
-      assert_equal 'three-four-five', @myobj.myvalargs(3,4,5)
+      stub = MuchStub::Stub.new(@myobj, :myvalargs){ |*args| args.join(",") }
+      assert_equal "1,2,3", @myobj.myvalargs(1,2,3)
+      assert_equal "3,4,5", @myobj.myvalargs(3,4,5)
+      stub.with(3,4,5){ "three-four-five" }
+      assert_equal "three-four-five", @myobj.myvalargs(3,4,5)
     end
 
     should "stub methods that yield blocks" do
@@ -242,9 +240,9 @@ module MuchStub
       assert_equal true, blkcalled
 
       blkcalled = false
-      MuchStub::Stub.new(@myobj, :myblk){ blkcalled = 'true' }
+      MuchStub::Stub.new(@myobj, :myblk){ blkcalled = "true" }
       @myobj.myblk(&blk)
-      assert_equal 'true', blkcalled
+      assert_equal "true", blkcalled
     end
 
     should "stub methods even if they are not local to the object" do
@@ -263,56 +261,56 @@ module MuchStub
 
       assert_equal [1,2,[3]], mydelegator.myvalargs(1,2,3)
       stub = MuchStub::Stub.new(mydelegator, :myvalargs){ |*args| args.inspect }
-      assert_equal '[1, 2, 3]', mydelegator.myvalargs(1,2,3)
-      assert_equal '[4, 5, 6]', mydelegator.myvalargs(4,5,6)
-      stub.with(4,5,6){ 'four-five-six' }
-      assert_equal 'four-five-six', mydelegator.myvalargs(4,5,6)
+      assert_equal "[1, 2, 3]", mydelegator.myvalargs(1,2,3)
+      assert_equal "[4, 5, 6]", mydelegator.myvalargs(4,5,6)
+      stub.with(4,5,6){ "four-five-six" }
+      assert_equal "four-five-six", mydelegator.myvalargs(4,5,6)
     end
 
     should "call to the original method" do
       subject.teardown
 
       # no args
-      stub = MuchStub::Stub.new(@myobj, :mymeth){ 'mymeth' }
-      assert_equal 'mymeth', stub.call([])
-      assert_equal 'meth',   stub.call_method([])
+      stub = MuchStub::Stub.new(@myobj, :mymeth){ "mymeth" }
+      assert_equal "mymeth", stub.call([])
+      assert_equal "meth",   stub.call_method([])
 
       # static args
       stub = MuchStub::Stub.new(@myobj, :myval){ |val| val.to_s }
-      assert_equal '1', stub.call([1])
+      assert_equal "1", stub.call([1])
       assert_equal 1,   stub.call_method([1])
-      assert_equal '2', stub.call([2])
+      assert_equal "2", stub.call([2])
       assert_equal 2,   stub.call_method([2])
-      stub.with(2){ 'two' }
-      assert_equal 'two', stub.call([2])
+      stub.with(2){ "two" }
+      assert_equal "two", stub.call([2])
       assert_equal 2,     stub.call_method([2])
 
       # dynamic args
-      stub = MuchStub::Stub.new(@myobj, :myargs){ |*args| args.join(',') }
-      assert_equal '1,2',   stub.call([1,2])
+      stub = MuchStub::Stub.new(@myobj, :myargs){ |*args| args.join(",") }
+      assert_equal "1,2",   stub.call([1,2])
       assert_equal [1,2],   stub.call_method([1,2])
-      assert_equal '3,4,5', stub.call([3,4,5])
+      assert_equal "3,4,5", stub.call([3,4,5])
       assert_equal [3,4,5], stub.call_method([3,4,5])
-      stub.with(3,4,5){ 'three-four-five' }
-      assert_equal 'three-four-five', stub.call([3,4,5])
+      stub.with(3,4,5){ "three-four-five" }
+      assert_equal "three-four-five", stub.call([3,4,5])
       assert_equal [3,4,5],           stub.call_method([3,4,5])
 
       # mixed static/dynamic args
-      stub = MuchStub::Stub.new(@myobj, :myvalargs){ |*args| args.join(',') }
-      assert_equal '1,2,3',    stub.call([1,2,3])
+      stub = MuchStub::Stub.new(@myobj, :myvalargs){ |*args| args.join(",") }
+      assert_equal "1,2,3",    stub.call([1,2,3])
       assert_equal [1,2, [3]], stub.call_method([1,2,3])
-      assert_equal '3,4,5',    stub.call([3,4,5])
+      assert_equal "3,4,5",    stub.call([3,4,5])
       assert_equal [3,4,[5]],  stub.call_method([3,4,5])
-      stub.with(3,4,5){ 'three-four-five' }
-      assert_equal 'three-four-five', stub.call([3,4,5])
+      stub.with(3,4,5){ "three-four-five" }
+      assert_equal "three-four-five", stub.call([3,4,5])
       assert_equal [3,4,[5]],         stub.call_method([3,4,5])
 
       # blocks
       blkcalled = false
       blk = proc{ blkcalled = true }
-      stub = MuchStub::Stub.new(@myobj, :myblk){ blkcalled = 'true' }
+      stub = MuchStub::Stub.new(@myobj, :myblk){ blkcalled = "true" }
       stub.call([], &blk)
-      assert_equal 'true', blkcalled
+      assert_equal "true", blkcalled
       stub.call_method([], &blk)
       assert_equal true, blkcalled
     end
@@ -326,17 +324,16 @@ module MuchStub
     should "be removable" do
       assert_equal 1, @myobj.myval(1)
       stub = MuchStub::Stub.new(@myobj, :myval){ |val| val.to_s }
-      assert_equal '1', @myobj.myval(1)
+      assert_equal "1", @myobj.myval(1)
       stub.teardown
       assert_equal 1, @myobj.myval(1)
     end
 
     should "have a readable inspect" do
-      expected = "#<#{subject.class}:#{'0x0%x' % (subject.object_id << 1)}" \
+      expected = "#<#{subject.class}:#{"0x0%x" % (subject.object_id << 1)}" \
                  " @method_name=#{subject.method_name.inspect}>"
       assert_equal expected, subject.inspect
     end
-
   end
 
   class MutatingArgsStubTests < StubTests
@@ -354,7 +351,6 @@ module MuchStub
     should "not raise a stub error when called" do
       assert_nothing_raised{ @stub.call([@arg]) }
     end
-
   end
 
   class StubInheritedMethodAfterStubbedOnParentTests < StubTests
@@ -369,11 +365,11 @@ module MuchStub
 
     should "allow stubbing them independently of each other" do
       assert_nothing_raised do
-        @parent_stub.with(1, 2){ 'parent' }
-        @child_stub.with(1, 2){ 'child' }
+        @parent_stub.with(1, 2){ "parent" }
+        @child_stub.with(1, 2){ "child" }
       end
-      assert_equal 'parent', @parent_class.new(1, 2)
-      assert_equal 'child', @child_class.new(1, 2)
+      assert_equal "parent", @parent_class.new(1, 2)
+      assert_equal "child", @child_class.new(1, 2)
     end
 
     should "not raise any errors when tearing down the parent before the child" do
@@ -382,7 +378,6 @@ module MuchStub
         @child_stub.teardown
       end
     end
-
   end
 
   class NullStubTests < UnitTests
@@ -393,7 +388,6 @@ module MuchStub
     subject{ @ns }
 
     should have_imeths :teardown
-
   end
 
   class ParameterListTests < UnitTests
@@ -401,7 +395,7 @@ module MuchStub
     setup do
       many_args = (0..ParameterList::LETTERS.size).map do
         Assert::Factory.string
-      end.join(', ')
+      end.join(", ")
       @object = Class.new
       # use `class_eval` with string to easily define methods with many params
       @object.class_eval <<-methods
@@ -414,23 +408,22 @@ module MuchStub
     subject{ ParameterList }
 
     should "build a parameter list for a method that takes no args" do
-      assert_equal '&block', subject.new(@object, 'noargs')
+      assert_equal "&block", subject.new(@object, "noargs")
     end
 
     should "build a parameter list for a method that takes any args" do
-      assert_equal '*args, &block', subject.new(@object, 'anyargs')
+      assert_equal "*args, &block", subject.new(@object, "anyargs")
     end
 
     should "build a parameter list for a method that takes many args" do
-      expected = "#{ParameterList::LETTERS.join(', ')}, aa, &block"
-      assert_equal expected, subject.new(@object, 'manyargs')
+      expected = "#{ParameterList::LETTERS.join(", ")}, aa, &block"
+      assert_equal expected, subject.new(@object, "manyargs")
     end
 
     should "build a parameter list for a method that takes a minimum number of args" do
-      expected = "#{ParameterList::LETTERS.join(', ')}, aa, *args, &block"
-      assert_equal expected, subject.new(@object, 'minargs')
+      expected = "#{ParameterList::LETTERS.join(", ")}, aa, *args, &block"
+      assert_equal expected, subject.new(@object, "minargs")
     end
-
   end
 
   class ChangeHashObject
@@ -446,5 +439,4 @@ module MuchStub
       @value = 1
     end
   end
-
 end


### PR DESCRIPTION
This method is used to "tap" using a stub. This allows you to spy
on a method call while preserving the methods original behavior and
return value. You can also use this to late-bound stub the return
value of a stubbed method.

This is extracted from use-patterns we've seen using MuchStub in
production apps.

# Other Changes

### update README

This polishes the README by removing the abbreviations. In watching
other developers consume the README, it became apparent tha the
abbreviations were a bit of a distraction. This removes them to
avoid distracting users and make learning about MuchStub as easier.

This also adds a couple of sections for using generic stub blocks
to spy on method calls. This adds various examples of basic
argument spying and also test double spying.

All of this is to ease new developers in learning how to use
MuchStub and what types of tests are possible using it.

### update dependencies; update to our latest syntax conventions

* double-quoted strings
* no empty line at the end of class/module definitions