### PR TITLE
add MuchStub::Call and MuchStub::CallSpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,16 @@ basic_method_called_with
 
 basic_method_called_with = nil
 MuchStub.tap(my_object, :basic_method) { |value, *args|
-  basic_method_called_with = args
+  basic_method_called_with = MuchStub::Call.new(*args)
+}
+# OR
+MuchStub.tap_on_call(my_object, :basic_method) { |value, call|
+  basic_method_called_with = call
 }
 
 my_object.basic_method(123)
   # => "123"
-basic_method_called_with
+basic_method_called_with.args
   # => [123]
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,35 @@ basic_method_called_with = nil
 MuchStub.(my_object, :basic_method) { |*args|
   basic_method_called_with = MuchStub::Call.new(*args)
 }
+# OR
+MuchStub.(my_object, :basic_method).on_call { |call|
+  basic_method_called_with = call
+}
 
 my_object.basic_method(123)
 basic_method_called_with.args
   # => [123]
 
+basic_method_called_with = nil
+MuchStub.(my_object, :basic_method).with(4, 5, 6) { |*args|
+  basic_method_called_with = MuchStub::Call.new(*args)
+}
+# OR
+MuchStub.(my_object, :basic_method).with(4, 5, 6).on_call { |call|
+  basic_method_called_with = call
+}
+
+my_object.basic_method(4, 5, 6)
+basic_method_called_with.args
+  # => [4,5,6]
+
 iterator_method_called_with = nil
 MuchStub.(my_object, :iterator_method) { |*args, &block|
   iterator_method_called_with = MuchStub::Call.new(*args)
+}
+# OR
+MuchStub.(my_object, :iterator_method).on_call { |call|
+  iterator_method_called_with = call
 }
 
 my_object.iterator_method([1, 2, 3], &:to_s)
@@ -144,6 +165,10 @@ basic_method_call_count
 basic_method_calls = []
 MuchStub.(my_object, :basic_method) { |*args|
   basic_method_calls << MuchStub::Call.new(*args)
+}
+# OR
+MuchStub.(my_object, :basic_method).on_call { |call|
+  basic_method_calls << call
 }
 
 my_object.basic_method(123)

--- a/README.md
+++ b/README.md
@@ -293,6 +293,39 @@ thing.value
   # => 456
 ```
 
+### `MuchStub.spy`
+
+Use the `.spy` method to spy on method calls. This is especially helpful for spying on _chained_ method calls.
+
+```ruby
+# Given this object/API
+
+myclass = Class.new do
+  def one; self; end
+  def two(val); self; end
+  def three; self; end
+  def ready?; false; end
+end
+myobj = myclass.new
+
+spy =
+  MuchStub.spy(myobj :one, :two, :three, ready?: true)
+
+assert_equal spy, myobj.one
+assert_equal spy, myobj.two("a")
+assert_equal spy, myobj.three
+
+assert_true myobj.one.two("b").three.ready?
+
+assert_kind_of MuchStub::CallSpy, spy
+assert_equal 2, spy.one_call_count
+assert_equal 2, spy.two_call_count
+assert_equal 2, spy.three_call_count
+assert_equal 1, spy.ready_predicate_call_count
+assert_equal ["b"], spy.two_last_called_with.args
+assert_true spy.ready_predicate_called?
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -110,24 +110,22 @@ my_object = my_class.new
 
 basic_method_called_with = nil
 MuchStub.(my_object, :basic_method) { |*args|
-  basic_method_called_with = args
+  basic_method_called_with = MuchStub::Call.new(*args)
 }
 
 my_object.basic_method(123)
-basic_method_called_with
+basic_method_called_with.args
   # => [123]
 
-iterator_method_call_args = nil
-iterator_method_call_block = nil
+iterator_method_called_with = nil
 MuchStub.(my_object, :iterator_method) { |*args, &block|
-  iterator_method_call_args = args
-  iterator_method_call_block = block
+  iterator_method_called_with = MuchStub::Call.new(*args)
 }
 
 my_object.iterator_method([1, 2, 3], &:to_s)
-iterator_method_call_args
+iterator_method_called_with.args
   # => [[1, 2, 3]]
-iterator_method_call_block
+iterator_method_called_with.block
   # => #<Proc:0x00007fb083a6feb0(&:to_s)>
 
 # Count method calls for spying.
@@ -145,13 +143,13 @@ basic_method_call_count
 
 basic_method_calls = []
 MuchStub.(my_object, :basic_method) { |*args|
-  basic_method_calls << args
+  basic_method_calls << MuchStub::Call.new(*args)
 }
 
 my_object.basic_method(123)
 basic_method_calls.size
   # => 1
-basic_method_calls.first
+basic_method_calls.first.args
   # => [123]
 ```
 

--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -1,5 +1,7 @@
 require "much-stub/version"
+
 require "much-stub/call"
+require "much-stub/call_spy"
 
 module MuchStub
   def self.stubs
@@ -55,6 +57,16 @@ module MuchStub
     self.tap(obj, meth) { |value, *args, &block|
       on_call_block.call(value, MuchStub::Call.new(*args, &block)) if on_call_block
     }
+  end
+
+  def self.spy(obj, *meths, **return_values)
+    MuchStub::CallSpy.new(**return_values).tap do |spy|
+      meths.each do |meth|
+        self.stub(obj, meth) { |*args, &block|
+          spy.public_send(meth, *args, &block)
+        }
+      end
+    end
   end
 
   class Stub

--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -1,4 +1,5 @@
 require "much-stub/version"
+require "much-stub/call"
 
 module MuchStub
   def self.stubs

--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -51,6 +51,12 @@ module MuchStub
     }
   end
 
+  def self.tap_on_call(obj, meth, &on_call_block)
+    self.tap(obj, meth) { |value, *args, &block|
+      on_call_block.call(value, MuchStub::Call.new(*args, &block)) if on_call_block
+    }
+  end
+
   class Stub
     def self.key(object, method_name)
       "--#{object.object_id}--#{method_name}--"

--- a/lib/much-stub/call.rb
+++ b/lib/much-stub/call.rb
@@ -1,0 +1,15 @@
+module MuchStub
+  class Call
+    attr_reader :pargs, :kargs, :block
+
+    def initialize(*pargs, **kargs, &block)
+      @pargs = pargs.empty? ? nil : pargs
+      @kargs = kargs.empty? ? nil : kargs
+      @block = block
+    end
+
+    def args
+      @args ||= [*pargs, kargs].compact
+    end
+  end
+end

--- a/lib/much-stub/call_spy.rb
+++ b/lib/much-stub/call_spy.rb
@@ -1,0 +1,91 @@
+require "much-stub/call"
+
+module MuchStub
+  class CallSpy
+    METHOD_NAME_REPLACEMENTS = {
+      "!" => "_bang",
+      "?" => "_predicate"
+    }.freeze
+
+    def initialize(**return_values)
+      @call_spy_return_values = return_values.transform_keys{ |key| key.to_s }
+
+      @call_spy_method_calls = Hash.new { |hash, key| hash[key] = [] }
+      @call_spy_method_return_values =
+        Hash.new { |hash, key| hash[key] = call_spy_return_value_proc(key) }
+    end
+
+    private
+
+    def call_spy_method_return_value(method_name, much_stub_call)
+      @call_spy_method_return_values[method_name.to_s].call(much_stub_call)
+    end
+
+    def call_spy_return_value_proc(method_name)
+      value = @call_spy_return_values[method_name]
+      return value if value.respond_to?(:call)
+
+      ->(*) { value.nil? ? self : value }
+    end
+
+    def call_spy_normalize_method_name(name)
+      METHOD_NAME_REPLACEMENTS.reduce(name.to_s) { |acc, (source, replacement)|
+        acc.gsub(source, replacement)
+      }
+    end
+
+    def call_spy_define_spied_method(name)
+      method_name = call_spy_normalize_method_name(name)
+      self.define_singleton_method(name) do |*args, &block|
+        call = MuchStub::Call.new(*args, &block)
+        @call_spy_method_calls[method_name] << call
+        call_spy_method_return_value(name, call)
+      end
+    end
+
+    def call_spy_define_query_method(query_method_match)
+      spied_method_name = query_method_match[1]
+      query_method_suffix = query_method_match[2]
+      method_name = call_spy_normalize_method_name(spied_method_name)
+      self.define_singleton_method("#{method_name}#{query_method_suffix}") do
+        yield(method_name) if block_given?
+      end
+    end
+
+    def method_missing(name, *args, &block)
+      if (match = name.match(/(\w+)(_calls)\z/))
+        call_spy_define_query_method(match) do |method_name|
+          @call_spy_method_calls[method_name]
+        end
+        self.send(name, *args, &block)
+      elsif (match = name.match(/(\w+)(_last_called_with)\z/))
+        call_spy_define_query_method(match) do |method_name|
+          self.send("#{method_name}_calls").last
+        end
+        self.send(name, *args, &block)
+      elsif (match = name.match(/(\w+)(_called_with)\z/))
+        call_spy_define_query_method(match) do |method_name|
+          self.send("#{method_name}_last_called_with")
+        end
+        self.send(name, *args, &block)
+      elsif (match = name.match(/(\w+)(_call_count)\z/))
+        call_spy_define_query_method(match) do |method_name|
+          self.send("#{method_name}_calls").size
+        end
+        self.send(name, *args, &block)
+      elsif (match = name.match(/(\w+)(_called\?)\z/))
+        call_spy_define_query_method(match) do |method_name|
+          self.send("#{method_name}_call_count") > 0
+        end
+        self.send(name, *args, &block)
+      else
+        call_spy_define_spied_method(name)
+        self.send(name, *args, &block)
+      end
+    end
+
+    def respond_to_missing?(*args)
+      super
+    end
+  end
+end

--- a/much-stub.gemspec
+++ b/much-stub.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.18.0"])
+  gem.required_ruby_version = "~> 2.5"
+
+  gem.add_development_dependency("assert", ["~> 2.18.1"])
 
 end

--- a/test/unit/call_spy_tests.rb
+++ b/test/unit/call_spy_tests.rb
@@ -1,0 +1,96 @@
+require "assert"
+require "much-stub/call_spy"
+
+require "test/support/factory"
+
+class MuchStub::CallSpy
+  class UnitTests < Assert::Context
+    desc "MuchStub::CallSpy"
+    setup do
+      @unit_class = MuchStub::CallSpy
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    before do
+      @spy = @unit_class.new
+    end
+    subject{ @spy }
+
+    should "spy on method calls and return itself" do
+      assert_false subject.respond_to?(:get)
+
+      assert_equal [], subject.get_calls
+      assert_nil subject.get_last_called_with
+      assert_nil subject.get_called_with
+      assert_equal 0, subject.get_call_count
+      assert_false subject.get_called?
+
+      assert_same subject, subject.get
+
+      assert_true subject.respond_to?(:get)
+
+      assert_kind_of Array, subject.get_calls
+      assert_kind_of MuchStub::Call, subject.get_last_called_with
+      assert_equal [], subject.get_last_called_with.args
+      assert_equal subject.get_last_called_with, subject.get_called_with
+      assert_equal 1, subject.get_call_count
+      assert_true subject.get_called?
+
+      assert_same subject, subject.set!("value1")
+      assert_same subject, subject.set!("value2")
+
+      assert_kind_of Array, subject.set_bang_calls
+      assert_kind_of MuchStub::Call, subject.set_bang_last_called_with
+      assert_equal ["value2"], subject.set_bang_last_called_with.args
+      assert_equal 2, subject.set_bang_call_count
+      assert_true subject.set_bang_called?
+    end
+
+    should "normalize method names in call query methods" do
+      assert_same subject, subject.set!("value1")
+      assert_kind_of Array, subject.set_bang_calls
+      assert_kind_of MuchStub::Call, subject.set_bang_last_called_with
+      assert_equal ["value1"], subject.set_bang_last_called_with.args
+      assert_equal ["value1"], subject.set_bang_called_with.args
+      assert_equal 1, subject.set_bang_call_count
+      assert_true subject.set_bang_called?
+
+      assert_same subject, subject.any?
+      assert_kind_of Array, subject.any_predicate_calls
+      assert_kind_of MuchStub::Call, subject.any_predicate_last_called_with
+      assert_kind_of MuchStub::Call, subject.any_predicate_called_with
+      assert_equal 1, subject.any_predicate_call_count
+      assert_true subject.any_predicate_called?
+    end
+  end
+
+  class InitWithReturnValuesTests < UnitTests
+    desc "when init with return values"
+    setup do
+      @spy = @unit_class.new(any?: false)
+    end
+    subject{ @spy }
+
+    should "return the given values instead of itself if that method is called" do
+      assert_false subject.get.set!("value1").any?
+      assert_true subject.get_called?
+      assert_equal ["value1"], subject.set_bang_called_with.args
+      assert_true subject.any_predicate_called?
+    end
+  end
+
+  class InitWithReturnValueProcsTests < UnitTests
+    desc "when init with return value procs"
+    setup do
+      @result = Factory.boolean
+      @spy = @unit_class.new(any?: ->(call) { @result })
+    end
+    subject{ @spy }
+
+    should "return the value of calling the procs instead of itself" do
+      assert_equal @result, subject.get.set!("value1").any?
+    end
+  end
+end

--- a/test/unit/call_tests.rb
+++ b/test/unit/call_tests.rb
@@ -1,0 +1,68 @@
+require "assert"
+require "much-stub/call"
+
+require "test/support/factory"
+
+class MuchStub::Call
+  class UnitTests < Assert::Context
+    desc "MuchStub::Call"
+    setup do
+      @unit_class = MuchStub::Call
+
+      @pargs = [Factory.string, Factory.integer]
+      @kargs = {
+        one: 1,
+        two: 2
+      }
+      @block = -> {}
+    end
+  end
+
+  class InitWithNoArgsTests < UnitTests
+    desc "when init with no args"
+    subject{ @unit_class.new }
+
+    should "know its attrs" do
+      assert_nil subject.pargs
+      assert_nil subject.kargs
+      assert_equal [], subject.args
+      assert_nil subject.block
+    end
+  end
+
+  class InitWithOnlyPositionalArgsTests < UnitTests
+    desc "when init with only positional args"
+    subject{ @unit_class.new(*@pargs) }
+
+    should "know its attrs" do
+      assert_equal @pargs, subject.pargs
+      assert_nil subject.kargs
+      assert_equal [*@pargs], subject.args
+      assert_nil subject.block
+    end
+  end
+
+  class InitWithOnlyKeywordArgsTests < UnitTests
+    desc "when init with only keyword args"
+    subject{ @unit_class.new(**@kargs) }
+
+    should "know its attrs" do
+      assert_nil subject.pargs
+      assert_equal @kargs, subject.kargs
+      assert_equal [@kargs], subject.args
+      assert_nil subject.block
+    end
+  end
+
+  class InitWithBothPositionalAndKeywordArgsTests < UnitTests
+    desc "when init with only keyword args"
+    subject{ @unit_class.new(*@pargs, **@kargs, &@block) }
+
+    should "know its attrs" do
+      assert_equal @pargs, subject.pargs
+      assert_equal @kargs, subject.kargs
+      assert_equal [*@pargs, @kargs], subject.args
+      assert_equal @block, subject.block
+    end
+  end
+end

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -86,6 +86,16 @@ module MuchStub
       assert_equal @orig_value, @myobj.mymeth
       assert_equal [], my_meth_called_with
     end
+
+    should "be able to add a stub tap with an on_call block" do
+      my_meth_called_with = nil
+      MuchStub.tap_on_call(@myobj, :mymeth){ |value, call|
+        my_meth_called_with = call
+      }
+
+      assert_equal @orig_value, @myobj.mymeth
+      assert_equal [], my_meth_called_with.args
+    end
   end
 
   class StubTests < UnitTests

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -96,6 +96,38 @@ module MuchStub
       assert_equal @orig_value, @myobj.mymeth
       assert_equal [], my_meth_called_with.args
     end
+
+    should "be able to add a stubbed spy" do
+      myclass = Class.new do
+        def one; self; end
+        def two(val); self; end
+        def three; self; end
+        def ready?; false; end
+      end
+      myobj = myclass.new
+
+      spy =
+        MuchStub.spy(
+          myobj,
+          :one,
+          :two,
+          :three,
+          ready?: true)
+
+      assert_equal spy, myobj.one
+      assert_equal spy, myobj.two("a")
+      assert_equal spy, myobj.three
+
+      assert_true myobj.one.two("b").three.ready?
+
+      assert_kind_of MuchStub::CallSpy, spy
+      assert_equal 2, spy.one_call_count
+      assert_equal 2, spy.two_call_count
+      assert_equal 2, spy.three_call_count
+      assert_equal 1, spy.ready_predicate_call_count
+      assert_equal ["b"], spy.two_last_called_with.args
+      assert_true spy.ready_predicate_called?
+    end
   end
 
   class StubTests < UnitTests


### PR DESCRIPTION
# Summary

MuchStub::Call is a new parser/accessor for call arguments:
```ruby
call = MuchStub::Call.new(1, 2, 3, key: "value") { "block return value" }
call.args # => [1, 2, 3, { :key => "value" }]
call.pargs # => [1, 2, 3] # i.e. "positional arguments"
call.kargs # => { :key => "value" } # i.e. "keyword arguments"
call.block.call # => "block return value"
```

MuchStub's API has been extended to optionally yield MuchStub::Call objects instead of the raw arguments:
```ruby
MuchStub.(Thing.new, :some_method).on_call { |call| ... }
MuchStub.(Thing.new, :some_method).with("some argument").on_call { |call| ... }
MuchStub.tap_on_call(Thing.new, :some_method) { |thing, call| ... }
```

MuchStub::CallSpy is a generic spy object that responds to any method call and
spies on any methods called on it:
```ruby
spy = MuchStub::CallSpy.new
spy.some_method_called? # => false

spy.some_method("some value1") # => spy # i.e. spy methods return the spy by default
spy.some_method("some value2") # => spy

spy.some_method_called? # => true
spy.some_method_call_count # => 2
spy.some_method_last_called_with.args # => ["some value2"]
spy.some_method_called_with.args # => ["some value2"] # i.e. an alias for `*_last_called_with`
spy.some_method_calls.first.args # => ["some value1"] # i.e. `*_calls` and `*_called_with` return MuchStub::Call instances
```

By default `MuchStub::CallSpy`s methods always return the spy instance itself. You can override this by passing in return values:
```ruby
spy = MuchStub::CallSpy.new(some_method: "some return value")
spy.some_method_called? # => false

spy.some_method # => "some return value"
spy.some_method_called? # => true
```

There is a new `MuchStub.spy` method to stub in `MuchStub::CallSpy`s. This is helpful when you need to stub and spy on calls your test unit makes on other external objects:
```ruby
spy = MuchStub.spy(other_object, :method1, :method2, :method3)

# test code the makes method calls on `other_object`

assert spy.method1_called?
assert spy.method2_called?
assert !spy.method3_called?
```

# Commits

### add MuchStub::Call

This is a utility for working with stubbed method arguments. It
parses any arguments and organizes them into positional and keyword
argument readers for easier access. This can help avoid boilerplate
in parsing out the keyword arguments from the positional arguments
in stubs.

### add `.on_call` method to yield MuchStub::Call objects to stub blocks

Now that MuchStub has the MuchStub::Call object that handles
parsing/accessing variable call arguments, it would be nice to
specify stub blocks where this call object is yielded instead of
the raw arguments. This reduces boilerplate from having to manually
build the `MuchStub::Call` objects.

### add `MuchStub.tap_on_call`

This allows adding a tap with a block that yields a MuchStub::Call
object instead of the raw arguments/block.

### add MuchStub::CallSpy; add MuchStub.spy handling

`MuchStub::CallSpy` allows for spying on object instances. It
responds to the same methods a given instance responds to and
collects data on any methods that are called on the spy.

`MuchStub.spy` allows stubbing in a CallSpy on object method
calls.

### make arity checking logic reusable

I thought I would need to reuse the logic elsewhere in the gem but
I didn't end up needing this after all. However, there is no harm
with the logic being reusable. Also, this has the nice side-effect
of DRYing up the `StubArityError` message handling.

