### PR TITLE
switch MuchStub::CallSpy to be a BasicObject

### DIFF
--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -60,10 +60,10 @@ module MuchStub
   end
 
   def self.spy(obj, *meths, **return_values)
-    MuchStub::CallSpy.new(**return_values).tap do |spy|
+    MuchStub::CallSpy.new(**return_values).call_spy_tap do |spy|
       meths.each do |meth|
         self.stub(obj, meth) { |*args, &block|
-          spy.public_send(meth, *args, &block)
+          spy.__send__(meth, *args, &block)
         }
       end
     end

--- a/test/unit/call_spy_tests.rb
+++ b/test/unit/call_spy_tests.rb
@@ -4,7 +4,7 @@ require "much-stub/call_spy"
 require "test/support/factory"
 
 class MuchStub::CallSpy
-  class UnitTests < Assert::Context
+  class UnitTests < ::Assert::Context
     desc "MuchStub::CallSpy"
     setup do
       @unit_class = MuchStub::CallSpy
@@ -19,7 +19,7 @@ class MuchStub::CallSpy
     subject{ @spy }
 
     should "spy on method calls and return itself" do
-      assert_false subject.respond_to?(:get)
+      assert_true subject.respond_to?(:get)
 
       assert_equal [], subject.get_calls
       assert_nil subject.get_last_called_with

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -112,11 +112,13 @@ module MuchStub
           :one,
           :two,
           :three,
+          :to_s,
           ready?: true)
 
       assert_equal spy, myobj.one
       assert_equal spy, myobj.two("a")
       assert_equal spy, myobj.three
+      assert_equal spy, myobj.to_s
 
       assert_true myobj.one.two("b").three.ready?
 
@@ -124,6 +126,7 @@ module MuchStub
       assert_equal 2, spy.one_call_count
       assert_equal 2, spy.two_call_count
       assert_equal 2, spy.three_call_count
+      assert_equal 1, spy.to_s_call_count
       assert_equal 1, spy.ready_predicate_call_count
       assert_equal ["b"], spy.two_last_called_with.args
       assert_true spy.ready_predicate_called?


### PR DESCRIPTION
Since MuchStub::CallSpy uses `method_missing` to capture method
calls for spying, it needs most methods to be undefined on itself
so they can be spied upon. Switching to subclassing BasicObject
instead of Object reduces the number of defaultly defined methods
on a MuchStub::CallSpy which means you can now spy upon standard
Object methods such as `to_s` where you couldn't before.

Note: the switch to BasicObject significantly changed the CallSpy
implementation in a number of ways:

* I had to switch to explicate constant references (e.g. `::Hash`)
  due to no longer sharing the same `Object` ancestor.
* I had to switch to BasicObject equivalents of standard object
  methods (e.g. `.send` -> `.__send__`).
* I had to add explicit `::Kernel.` prefix to all implicit Kernel
  method calls.
* I had to re-define some standard Object methods like equality
  checks and `inspect` needed for testing and general usage. This
  means they can't be spied but I figure the utility of spying
  these is pretty low as they typically aren't overridden in most
  classes.
* I had to define my own `.tap` method. I chose to name it
  `.call_spy_tap` to namespace it like the other instance methods.
  This keeps from polluting the spy method-space too much.