### PR TITLE
add MuchStub.{stub_}on_call

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ MuchStub.(my_object, :basic_method) { |*args|
 MuchStub.(my_object, :basic_method).on_call { |call|
   basic_method_called_with = call
 }
+# OR
+MuchStub.on_call(my_object, :basic_method) { |call|
+  # MucStub.on_call(...) { ... } is equivalent to
+  # MuchStub.(...).on_call { ... }
+  basic_method_called_with = call
+}
 
 my_object.basic_method(123)
 basic_method_called_with.args

--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -18,14 +18,22 @@ module MuchStub
     return false
   end
 
-  def self.call(*args, &block)
-    self.stub(*args, &block)
-  end
-
   def self.stub(obj, meth, &block)
     key = self.stub_key(obj, meth)
     self.stubs[key] ||= MuchStub::Stub.new(obj, meth, caller_locations)
     self.stubs[key].tap{ |s| s.do = block }
+  end
+
+  def self.call(*args, &block)
+    self.stub(*args, &block)
+  end
+
+  def self.stub_on_call(*args, &on_call_block)
+    self.stub(*args).on_call(&on_call_block)
+  end
+
+  def self.on_call(*args, &on_call_block)
+    self.stub_on_call(*args, &on_call_block)
   end
 
   def self.unstub(obj, meth)

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -25,8 +25,30 @@ module MuchStub
       stub1 = MuchStub.(@myobj, :mymeth)
       assert_kind_of MuchStub::Stub, stub1
 
-      stub2 = MuchStub.call(@myobj, :mymeth)
+      stub2 = MuchStub.stub(@myobj, :mymeth)
       assert_kind_of MuchStub::Stub, stub2
+    end
+
+    should "build a stub with an on_call block" do
+      my_meth_called_with = nil
+      stub1 =
+        MuchStub.on_call(@myobj, :mymeth) { |call|
+          my_meth_called_with = call
+        }
+
+      @myobj.mymeth
+      assert_kind_of MuchStub::Stub, stub1
+      assert_equal [], my_meth_called_with.args
+
+      my_meth_called_with = nil
+      stub2 =
+        MuchStub.stub_on_call(@myobj, :mymeth) { |call|
+          my_meth_called_with = call
+        }
+
+      @myobj.mymeth
+      assert_kind_of MuchStub::Stub, stub2
+      assert_equal [], my_meth_called_with.args
     end
 
     should "lookup stubs that have been called before" do


### PR DESCRIPTION
This is a macro method for `MuchStub.(...).on_call { ... }`. It has 
the same behavior just in a non-chained method call form.

This is similar to how there is a `MuchStub.tap_on_call` method
that is equivalent to doing a `MuchStub.tap` with an on call block.