### PR TITLE
Fix bug when building CallSpy with `nil` return values

### DIFF
--- a/lib/much-stub/call_spy.rb
+++ b/lib/much-stub/call_spy.rb
@@ -54,10 +54,8 @@ module MuchStub
     end
 
     def call_spy_return_value_proc(method_name)
-      value = @call_spy_return_values[method_name]
-      return value if value.respond_to?(:call)
-
-      ::Proc.new { value.nil? ? self : value }
+      value = @call_spy_return_values.fetch(method_name, ::Proc.new { self })
+      value.respond_to?(:call) ? value : ::Proc.new { value }
     end
 
     def call_spy_normalize_method_name(name)

--- a/test/unit/call_spy_tests.rb
+++ b/test/unit/call_spy_tests.rb
@@ -93,4 +93,16 @@ class MuchStub::CallSpy
       assert_equal @result, subject.get.set!("value1").any?
     end
   end
+
+  class InitWithNilReturnValuesTests < UnitTests
+    desc "when init with nil return values"
+    setup do
+      @spy = @unit_class.new(result: nil)
+    end
+    subject{ @spy }
+
+    should "return nil" do
+      assert_equal "nil", subject.get.set!("value1").result.inspect
+    end
+  end
 end


### PR DESCRIPTION
Before this change, when a CallSpy was created with `nil` return
values, those values would never get returned. This was because
`call_spy_return_value_proc` method was always returning the
instance of the CallSpy when the return value was `nil`.

That method was attempting to detect whether a return value had
been specified, however, a `nil` check is not sufficient because
a user could intend to specify a `nil` return value. A better
approach for this is to do a `key` check on the return values
hash. I chose to use `fetch` with a default value to avoid an
extra conditional.