### PR TITLE
update combining pargs so nil arg values aren't removed

### DIFF
--- a/lib/much-stub.rb
+++ b/lib/much-stub.rb
@@ -236,7 +236,7 @@ module MuchStub
     end
 
     def combined_args(pargs, kargs)
-      [*pargs, (kargs.empty? ? nil : kargs)].compact
+      pargs + [(kargs.empty? ? nil : kargs)].compact
     end
   end
 

--- a/test/unit/much-stub_tests.rb
+++ b/test/unit/much-stub_tests.rb
@@ -288,6 +288,7 @@ module MuchStub
       assert_raises(MuchStub::StubArityError){ @myobj.myvalargs }
       assert_raises(MuchStub::StubArityError){ @myobj.myvalargs(1) }
       assert_nothing_raised{ @myobj.myvalargs(1, 2) }
+      assert_nothing_raised{ @myobj.myvalargs(1, nil) }
       assert_nothing_raised{ @myobj.myvalargs(1, 2, 3) }
     end
 


### PR DESCRIPTION
Using `*pargs` has the side-effect of removing any `nil` values
in the positional args array. The causes false-positive arity
mismatches in this scenario.

I noticed this b/c I updated to the latest much-stub in another
gem and started seeing arity mismatches.
